### PR TITLE
Mentioning libomp in the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ In the future, we plan to expand the NDK's features to incorporate additional fu
 The initial release of NDK provides support for transcranial functional ultrasound stimulation, with a focus on providing comprehensive documentation, API flexibility, and visualizations.
 The Neurotech Development Kit is actively developed and we welcome feedback and contributions.
 
-
 ## Exploring the Repository
 
 The NDK API was developed with easy-of-use in mind, and **3 lines of code is all you need to run a simulation**:
@@ -38,16 +37,32 @@ result.render_steady_state_amplitudes()
 
 You can install the package using:
 
-``` bash
+```bash
 pip install neurotechdevkit
 ```
 
 And then you must install stride using:
-``` bash
+
+```bash
 pip install git+https://github.com/trustimaging/stride
 ```
 
-### Development
+`devito`, a dependency of `neurotechdevkit`, requires `libomp` to perform its runtime compilation. It can be installed on *MacOS* with:
+
+```
+brew install libomp
+```
+
+You will also have to set an environment variable that defines what compiler `devito` will use, like so:
+
+```
+export DEVITO_ARCH=clang
+```
+
+the supported values for `DEVITO_ARCH` are: `'custom', 'gnu', 'gcc', 'clang', 'aomp', 'pgcc', 'pgi', 'nvc', 'nvc++', 'nvidia', 'cuda', 'osx', 'intel', 'icpc', 'icc', 'intel-knl', 'knl', 'dpcpp', 'gcc-4.9', 'gcc-5', 'gcc-6', 'gcc-7', 'gcc-8', 'gcc-9', 'gcc-10', 'gcc-11'`
+
+
+## Development
 
 See our [contribution requirements](docs/contributing.md) for more information on how to install the package locally using poetry and on how to contribute.
 
@@ -61,6 +76,6 @@ $ make test
 
 See the Makefile for other commands.
 
-### Acknowledgements
+## Acknowledgements
 
 Thanks to Fred Ehrsam for supporting this project, Quintin Frerichs and Milan Cvitkovic for providing direction, and to Sumner Norman for his ultrasound and neuroscience expertise. Thanks to [Stride](https://www.stride.codes/) for facilitating ultrasound simulations, [Devito](https://www.devitoproject.org/) for providing the backend solver, [Napari](https://napari.org/stable/) for great 3D visualization, and to [Jean-Francois Aubry, et al.](https://doi.org/10.1121/10.0013426) for the basis of the simulation scenarios.

--- a/README.md
+++ b/README.md
@@ -33,36 +33,51 @@ result.render_steady_state_amplitudes()
 
 ## Setup
 
-`neurotechdevkit` requires Python `>=3.9` and `<3.11` to be installed. You can find which Python version you have installed by running `python --version` in a terminal. If you don't have Python installed, or you are running an unsupported version, you can download it from [python.org](https://www.python.org/downloads/). Python environment managers like pyenv, conda, and poetry are all perfectly suitable as well.
+`neurotechdevkit` requires Python `>=3.9` and `<3.11` to be installed. You can find which Python version you have installed by running `python --version` in a terminal.
 
-You can install the package using:
+If you don't have Python installed, or you are running an unsupported version, you can download it from [python.org](https://www.python.org/downloads/). Python environment managers like pyenv, conda, and poetry are all perfectly suitable as well.
+
+You can install the `neurotechdevkit` package using:
 
 ```bash
 pip install neurotechdevkit
 ```
 
-And then you must install stride using:
+You also have to install stride, it can be done running:
 
 ```bash
 pip install git+https://github.com/trustimaging/stride
 ```
 
-`devito`, a dependency of `neurotechdevkit`, requires `libomp` to perform its runtime compilation. It can be installed on *MacOS* with:
+`devito`, a dependency of `neurotechdevkit`, requires `libomp`. On MacOS it can be installed with:
 
 ```
 brew install libomp
 ```
 
+the output of the command above will look like this:
+
+```
+For compilers to find libomp you may need to set:
+export LDFLAGS="-L/usr/local/opt/libomp/lib"
+export CPPFLAGS="-I/usr/local/opt/libomp/include"
+```
+
+`devito` requires the directory with `libomp` headers to be accessible during the runtime compilation, you can make it accessible by exporting a new environment variable `CPATH` with the path for libomp headers, like so:
+
+```
+export CPATH="/usr/local/opt/libomp/include"
+```
+
 You will also have to set an environment variable that defines what compiler `devito` will use, like so:
 
 ```
-export DEVITO_ARCH=clang
+export DEVITO_ARCH=gcc
 ```
 
 the supported values for `DEVITO_ARCH` are: `'custom', 'gnu', 'gcc', 'clang', 'aomp', 'pgcc', 'pgi', 'nvc', 'nvc++', 'nvidia', 'cuda', 'osx', 'intel', 'icpc', 'icc', 'intel-knl', 'knl', 'dpcpp', 'gcc-4.9', 'gcc-5', 'gcc-6', 'gcc-7', 'gcc-8', 'gcc-9', 'gcc-10', 'gcc-11'`
 
-
-## Development
+### Development
 
 See our [contribution requirements](docs/contributing.md) for more information on how to install the package locally using poetry and on how to contribute.
 
@@ -76,6 +91,6 @@ $ make test
 
 See the Makefile for other commands.
 
-## Acknowledgements
+### Acknowledgements
 
 Thanks to Fred Ehrsam for supporting this project, Quintin Frerichs and Milan Cvitkovic for providing direction, and to Sumner Norman for his ultrasound and neuroscience expertise. Thanks to [Stride](https://www.stride.codes/) for facilitating ultrasound simulations, [Devito](https://www.devitoproject.org/) for providing the backend solver, [Napari](https://napari.org/stable/) for great 3D visualization, and to [Jean-Francois Aubry, et al.](https://doi.org/10.1121/10.0013426) for the basis of the simulation scenarios.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -64,20 +64,33 @@ Install stride with
 $ poetry run pip install git+https://github.com/trustimaging/stride
 ```
 
-`devito`, a dependency of `neurotechdevkit`, requires `libomp` to perform its runtime compilation. It can be installed on *MacOS* with:
+`devito`, a dependency of `neurotechdevkit`, requires `libomp`. On MacOS it can be installed with:
 
 ```
 brew install libomp
 ```
 
+the output of the command above will look like this:
+
+```
+For compilers to find libomp you may need to set:
+export LDFLAGS="-L/usr/local/opt/libomp/lib"
+export CPPFLAGS="-I/usr/local/opt/libomp/include"
+```
+
+`devito` requires the directory with `libomp` headers to be accessible during the runtime compilation, you can make it accessible by exporting a new environment variable `CPATH` with the path for libomp headers, like so:
+
+```
+export CPATH="/usr/local/opt/libomp/include"
+```
+
 You will also have to set an environment variable that defines what compiler `devito` will use, like so:
 
 ```
-export DEVITO_ARCH=clang
+export DEVITO_ARCH=gcc
 ```
 
 the supported values for `DEVITO_ARCH` are: `'custom', 'gnu', 'gcc', 'clang', 'aomp', 'pgcc', 'pgi', 'nvc', 'nvc++', 'nvidia', 'cuda', 'osx', 'intel', 'icpc', 'icc', 'intel-knl', 'knl', 'dpcpp', 'gcc-4.9', 'gcc-5', 'gcc-6', 'gcc-7', 'gcc-8', 'gcc-9', 'gcc-10', 'gcc-11'`
-
 
 
 ### Using the environment

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -36,6 +36,8 @@ If you don't want to install NDK's dependencies on your machine, you can run it 
 
 * Run the container, which will start a jupyter notebook server:
    ```
+   git clone https://github.com/agencyenterprise/neurotechdevkit.git
+   cd neurotechdevkit
    docker compose up
    ```
 
@@ -61,6 +63,22 @@ Install stride with
 ```bash
 $ poetry run pip install git+https://github.com/trustimaging/stride
 ```
+
+`devito`, a dependency of `neurotechdevkit`, requires `libomp` to perform its runtime compilation. It can be installed on *MacOS* with:
+
+```
+brew install libomp
+```
+
+You will also have to set an environment variable that defines what compiler `devito` will use, like so:
+
+```
+export DEVITO_ARCH=clang
+```
+
+the supported values for `DEVITO_ARCH` are: `'custom', 'gnu', 'gcc', 'clang', 'aomp', 'pgcc', 'pgi', 'nvc', 'nvc++', 'nvidia', 'cuda', 'osx', 'intel', 'icpc', 'icc', 'intel-knl', 'knl', 'dpcpp', 'gcc-4.9', 'gcc-5', 'gcc-6', 'gcc-7', 'gcc-8', 'gcc-9', 'gcc-10', 'gcc-11'`
+
+
 
 ### Using the environment
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,10 @@
 # Welcome to Neurotech Development Kit
 
-
 The _Neurotech Development Kit_ (NDK) is an open-source software library designed to enhance accessibility to cutting-edge neurotechnology. Featuring an easy-to-use API and pre-built examples, the NDK provides a seamless starting point for users. Moreover, the NDK offers educational resources, such as interactive simulations and notebook-based tutorials, catering to a diverse audience including researchers, educators, engineers, and trainees. By lowering the barrier of entry for newcomers and accelerating the progress of researchers, the NDK aims to be a versatile and invaluable tool for the neurotech community.
 
 The initial set of target users for the NDK are ultrasound simulation trainees – individuals with backgrounds in technical or neuroscience-related fields who are learning to perform ultrasound simulations. Our goal is to help users familiarize themselves with ultrasound simulation, understand the importance of input parameters, and streamline the process of running and visualizing simulations. In the future, we plan to expand the NDK's features to incorporate additional functionality and modalities, catering to a broader range of users, including ultrasound researchers, product developers, machine learning engineers, and many more.
 
 The initial release of NDK provides support for transcranial functional ultrasound stimulation, with a focus on providing comprehensive documentation, API flexibility, and visualizations. The Neurotech Development Kit is actively developed and we welcome feedback and contributions.
-
 
 <figure markdown>
   ![Simulation](images/ndk_example.gif){ width="900" }
@@ -20,16 +18,32 @@ The initial release of NDK provides support for transcranial functional ultrasou
 
 You can install the package using:
 
-``` bash
+```bash
 pip install neurotechdevkit
 ```
 
 And then you must install stride using:
-``` bash
+
+```bash
 pip install git+https://github.com/trustimaging/stride
 ```
 
+`devito`, a dependency of `neurotechdevkit`, requires `libomp` to perform its runtime compilation. It can be installed on _MacOS_ with:
+
+```
+brew install libomp
+```
+
+You will also have to set an environment variable that defines what compiler `devito` will use, like so:
+
+```
+export DEVITO_ARCH=clang
+```
+
+the supported values for `DEVITO_ARCH` are: `'custom', 'gnu', 'gcc', 'clang', 'aomp', 'pgcc', 'pgi', 'nvc', 'nvc++', 'nvidia', 'cuda', 'osx', 'intel', 'icpc', 'icc', 'intel-knl', 'knl', 'dpcpp', 'gcc-4.9', 'gcc-5', 'gcc-6', 'gcc-7', 'gcc-8', 'gcc-9', 'gcc-10', 'gcc-11'`
+
 ### Docker
+
 You can run `NDK` inside a docker container with a couple of steps:
 
 1. Install [docker](https://docs.docker.com/engine/install/#desktop)

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,30 +14,46 @@ The initial release of NDK provides support for transcranial functional ultrasou
 
 ### Local installation
 
-`neurotechdevkit` requires Python `>=3.9` and `<3.11` to be installed. You can find which Python version you have installed by running `python --version` in a terminal. If you don't have Python installed, or you are running an unsupported version, you can download it from [python.org](https://www.python.org/downloads/). Python environment managers like pyenv, conda, and poetry are all perfectly suitable as well.
+`neurotechdevkit` requires Python `>=3.9` and `<3.11` to be installed. You can find which Python version you have installed by running `python --version` in a terminal.
 
-You can install the package using:
+If you don't have Python installed, or you are running an unsupported version, you can download it from [python.org](https://www.python.org/downloads/). Python environment managers like pyenv, conda, and poetry are all perfectly suitable as well.
+
+You can install the `neurotechdevkit` package using:
 
 ```bash
 pip install neurotechdevkit
 ```
 
-And then you must install stride using:
+You also have to install stride, it can be done running:
 
 ```bash
 pip install git+https://github.com/trustimaging/stride
 ```
 
-`devito`, a dependency of `neurotechdevkit`, requires `libomp` to perform its runtime compilation. It can be installed on _MacOS_ with:
+`devito`, a dependency of `neurotechdevkit`, requires `libomp`. On MacOS it can be installed with:
 
 ```
 brew install libomp
 ```
 
+the output of the command above will look like this:
+
+```
+For compilers to find libomp you may need to set:
+export LDFLAGS="-L/usr/local/opt/libomp/lib"
+export CPPFLAGS="-I/usr/local/opt/libomp/include"
+```
+
+`devito` requires the directory with `libomp` headers to be accessible during the runtime compilation, you can make it accessible by exporting a new environment variable `CPATH` with the path for libomp headers, like so:
+
+```
+export CPATH="/usr/local/opt/libomp/include"
+```
+
 You will also have to set an environment variable that defines what compiler `devito` will use, like so:
 
 ```
-export DEVITO_ARCH=clang
+export DEVITO_ARCH=gcc
 ```
 
 the supported values for `DEVITO_ARCH` are: `'custom', 'gnu', 'gcc', 'clang', 'aomp', 'pgcc', 'pgi', 'nvc', 'nvc++', 'nvidia', 'cuda', 'osx', 'intel', 'icpc', 'icc', 'intel-knl', 'knl', 'dpcpp', 'gcc-4.9', 'gcc-5', 'gcc-6', 'gcc-7', 'gcc-8', 'gcc-9', 'gcc-10', 'gcc-11'`


### PR DESCRIPTION
#### Introduction
This PR extends the installation instructions mentioning the need of installing libomp and defining the DEVITO_ARCH environment variable