### PR TITLE
Replacing auto-generate GITHUB_TOKEN with Personal Access Token, since the main branch is protected

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.TAG_CREATOR_API_TOKEN }}
 
     steps:
       - id: release


### PR DESCRIPTION
The CI release job started to fail https://github.com/agencyenterprise/neurotechdevkit/actions/runs/4927431070/jobs/8804711715 after the `main` branch was protected.

A Personal Access Token from a repo admin should be able to bypass the branch restrictions and allow tagging again 