### PR TITLE
Adding Personal Access Token to push release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
+          token: ${{ secrets.TAG_CREATOR_API_TOKEN }}
 
       - name: Setup python
         uses: actions/setup-python@v4


### PR DESCRIPTION
As `main` is now a protected branch, it's impossible to commit and push the new poetry version. 
For this reason, the Personal Access Token has to be used.