### PR TITLE
Printing a warning when the DEVITO_ARCH environment variable was not set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY . /app
 RUN rm -rf /app/.git
 
 ENV PATH "/venv/bin:$PATH"
+ENV DEVITO_ARCH "gcc"
 
 LABEL org.opencontainers.image.source="https://github.com/agencyenterprise/neurotechdevkit"
 

--- a/src/neurotechdevkit/__init__.py
+++ b/src/neurotechdevkit/__init__.py
@@ -1,6 +1,8 @@
 """Main package for the neurotechdevkit."""
 from __future__ import annotations
 
+import os
+
 from . import scenarios
 from .scenarios import load_result_from_disk
 
@@ -10,6 +12,12 @@ __all__ = [
     "ScenarioNotFoundError",
     "load_result_from_disk",
 ]
+
+if "DEVITO_ARCH" not in os.environ:
+    print(
+        "WARNING: DEVITO_ARCH environment variable not set."
+        "Compilation errors might occur"
+    )
 
 
 class ScenarioNotFoundError(Exception):


### PR DESCRIPTION
#### Introduction
The DEVITO_ARCH environment variable defines how devito will interact with the system reading other environment variables to compile code.
Not having this environment variable set can generate various errors so this PR has a print statement when neurotechdevkit is imported but the variable was no set
