### PR TITLE
Add example notebooks to the gallery

### DIFF
--- a/docs/examples/plot_adding_custom_source.py
+++ b/docs/examples/plot_adding_custom_source.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+Custom source
+====================================
+
+This example demonstrates how to add a custom source to the simulation.
+"""
+# %%
+# A Source receives the following parameters:
+#
+#
+# - position `(npt.NDArray[np.float_])`: a numpy float array indicating the
+#   coordinates (in meters) of the point at the center of the source.
+# - direction `(npt.NDArray[np.float_])`: a numpy float array representing a vector
+#   located at position and pointing towards the focal point. Only the
+#   orientation of `direction` affects the source, the length of the vector has
+#   no affect. See the `unit_direction` property.
+# - aperture `(float)`: the width (in meters) of the source.
+# - focal_length `(float)`: the distance (in meters) from `position` to the focal
+#   point.
+# - num_points `(int)`: the number of point sources to use when simulating the source.
+# - delay `(float, optional)`: the delay (in seconds) that the source will wait before
+#   emitting. Defaults to 0.0.
+
+import numpy as np
+import neurotechdevkit as ndk
+
+source = ndk.sources.FocusedSource2D(
+    position=np.array([0.00, 0.0]),
+    direction=np.array([0.9, 0.0]),
+    aperture=0.01,
+    focal_length=0.01,
+    num_points=1000,
+)
+
+scenario = ndk.make('scenario-0-v0')
+scenario.add_source(source)
+result = scenario.simulate_steady_state()
+result.render_steady_state_amplitudes()
+
+# %%

--- a/docs/examples/plot_adding_custom_source.py
+++ b/docs/examples/plot_adding_custom_source.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """
-!!! note NDK and its examples are under constant development, more information and content will be added to this example soon!
 
 Custom source
 ====================================
+
+!!! note
+    NDK and its examples are under constant development, more information and content will be added to this example soon!
 
 This example demonstrates how to add a source to the simulation.
 """

--- a/docs/examples/plot_adding_custom_source.py
+++ b/docs/examples/plot_adding_custom_source.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """
+!!! note NDK and its examples are under constant development, more information and content will be added to this example soon!
+
 Custom source
 ====================================
 
-This example demonstrates how to add a custom source to the simulation.
+This example demonstrates how to add a source to the simulation.
 """
 # %%
 # A Source receives the following parameters:

--- a/docs/examples/plot_metrics.py
+++ b/docs/examples/plot_metrics.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 """
-!!! note NDK and its examples are under constant development, more information and content will be added to this example soon!
 
 Reading simulation metrics
 ====================================
+
+!!! note
+    NDK and its examples are under constant development, more information and content will be added to this example soon!
 
 This example demonstrates how to display the metrics collected from the simulation.
 """

--- a/docs/examples/plot_metrics.py
+++ b/docs/examples/plot_metrics.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-Reading metrics
+!!! note NDK and its examples are under constant development, more information and content will be added to this example soon!
+
+Reading simulation metrics
 ====================================
 
 This example demonstrates how to display the metrics collected from the simulation.

--- a/docs/examples/plot_metrics.py
+++ b/docs/examples/plot_metrics.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+Reading metrics
+====================================
+
+This example demonstrates how to display the metrics collected from the simulation.
+"""
+# %%
+# ## Rendering scenario
+import neurotechdevkit as ndk
+
+
+scenario = ndk.make('scenario-0-v0')
+result = scenario.simulate_steady_state()
+result.render_steady_state_amplitudes(show_material_outlines=False)
+
+# %%
+# ## Printing metrics
+for metric, metric_value in result.metrics.items():
+    print(f"{metric}:")
+    print(f"\t {metric_value['description']}")
+    print(f"\t Unit: {metric_value['unit-of-measurement']} Value: {metric_value['value']}")
+    print()

--- a/src/neurotechdevkit/__init__.py
+++ b/src/neurotechdevkit/__init__.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 import os
 
-from . import results, scenarios
+from . import scenarios, sources
 from .results import load_result_from_disk
 
 __all__ = [
     "results",
     "scenarios",
+    "sources",
     "make",
     "ScenarioNotFoundError",
     "load_result_from_disk",


### PR DESCRIPTION
#### Introduction
In this PR two new notebooks were added, one shows the simulation metrics, and the other one shows how an user can add a custom source to the simulation

<img width="834" alt="image" src="https://github.com/agencyenterprise/neurotechdevkit/assets/2744943/24e190a7-d2bc-415f-b962-45d6e9b26f60">

<img width="1086" alt="image" src="https://github.com/agencyenterprise/neurotechdevkit/assets/2744943/0171532e-2431-4e82-84d3-f57c41142b14">
