### PR TITLE
Adding GPU support documentation

### DIFF
--- a/docs/usage/gpu.md
+++ b/docs/usage/gpu.md
@@ -33,3 +33,6 @@ Operator `acoustic_iso_state` instance configuration:
 
 ...
 ```
+
+!!! warning
+	Simulations with high memory requirement (e.g. 3D simulations) may not fit in the GPU and running them with GPU acceleration might crash the simulation.

--- a/docs/usage/gpu.md
+++ b/docs/usage/gpu.md
@@ -1,0 +1,35 @@
+In order to use your GPU to run NDK simulations you will have to install the [NVIDIA HPC SDK](https://developer.nvidia.com/hpc-sdk-downloads).
+
+!!! warning
+    Make sure the [HPC SDK environment variables](https://docs.nvidia.com/hpc-sdk/hpc-sdk-install-guide/index.html#install-linux-end-usr-env-settings) are exported.
+
+You will only have to export one environment variable to enable the GPU support for NDK:
+
+```bash
+export PLATFORM="nvidia-acc"
+```
+
+Now when running NDK simulations you should be able to see `platform=nvidiaX` in the execution output:
+
+```py
+import neurotechdevkit as ndk
+
+scenario = ndk.make('scenario-2-2d-v0')
+result = scenario.simulate_steady_state()
+result.render_steady_state_amplitudes()
+```
+
+
+Output:
+```bash
+...
+
+Operator `acoustic_iso_state` instance configuration:
+	 * subs={h_x: 0.0005, h_y: 0.0005}
+	 * opt=advanced
+	 * compiler=pgcc
+	 * language=openacc
+	 * platform=nvidiaX
+
+...
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - Simulation: usage/running_simulation.md
       - 3D Visualization: usage/3d.md
       - Troubleshooting: usage/troubleshooting.md
+      - GPU support: usage/gpu.md
   - API:
       - Make: api/make.md
       - Scenarios: api/scenarios.md

--- a/src/neurotechdevkit/scenarios/_base.py
+++ b/src/neurotechdevkit/scenarios/_base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import asyncio
+import os
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Mapping
@@ -852,6 +853,7 @@ class Scenario(abc.ABC):
         devito_args = {}
         if n_jobs is not None:
             devito_args = dict(nthreads=n_jobs)
+
         assert sub_problem.shot is not None
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(
@@ -864,6 +866,7 @@ class Scenario(abc.ABC):
                 boundary_type="complex_frequency_shift_PML_2",
                 diff_source=True,
                 save_wavefield=True,
+                platform=os.environ.get("PLATFORM"),
                 save_bounds=save_bounds,
                 save_undersampling=save_undersampling,
                 wavefield_slice=wavefield_slice,


### PR DESCRIPTION
#### Introduction

This PR documents how a user can run the NDK simulation using the GPU #32 . 
This code was tested in an AWS instance with NVIDIA HPC preinstalled:
```
PLATFORM='nvidia-acc' python plot_full_scenario.py 
creating a grid with shape: (241, 141) for extent: [0.12 0.07] m
Estimated time to complete simulation: 47 seconds. Memory required is 8 GB (available 64.264081408 GB). These values are approximated.
Default Devito configuration:
	 * autotuning=off
	 * develop-mode=False
	 * mpi=False
	 * log-level=DEBUG
	 * language=openmp
(ShotID 0) Preparing to run state for shot
(ShotID 0) Estimated bandwidth for the propagated wavelet 0.497-0.502 MHz
(ShotID 0) Spatial grid spacing (0.500 mm | 5.981 PPW) is below dispersion limit (0.598 mm | 5.000 PPW)
(ShotID 0) Time grid spacing (0.083 μs | 46%) is above OT2 limit (0.080 μs) and below OT4 limit (0.145 μs)
(ShotID 0) Selected undersampling level 4
(ShotID 0) Selected time stepping scheme OT4
Operator `acoustic_iso_state` instance configuration:
	 * subs={h_x: 0.0005, h_y: 0.0005}
	 * opt=advanced
	 * compiler=pgcc
	 * language=openacc
	 * platform=nvidiaX
```

#### Changes

A `PLATFORM` environment variable is read when running the pde, by setting it to `nvidia-acc` the GPU can be used to run the simulation
