### PR TITLE
Moving _metrics.py to results folder

### DIFF
--- a/src/neurotechdevkit/results/_metrics.py
+++ b/src/neurotechdevkit/results/_metrics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import numpy.typing as npt
 
-from ..results import _results as results
+from . import _results as results
 
 
 def calculate_all_metrics(

--- a/src/neurotechdevkit/results/_results.py
+++ b/src/neurotechdevkit/results/_results.py
@@ -20,8 +20,8 @@ from matplotlib.animation import FuncAnimation
 import neurotechdevkit
 
 from .. import rendering, scenarios
-from ..scenarios import _metrics as metrics
 from ..scenarios._utils import drop_element, slice_field
+from . import _metrics as metrics
 
 DATA_FILENAME = "data.gz"
 

--- a/tests/neurotechdevkit/scenarios/test_metrics.py
+++ b/tests/neurotechdevkit/scenarios/test_metrics.py
@@ -3,8 +3,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from neurotechdevkit.results._results import SteadyStateResult2D
-from neurotechdevkit.scenarios._metrics import (
+from neurotechdevkit.results._metrics import (
     Conversions,
     calculate_all_metrics,
     calculate_focal_gain,
@@ -14,6 +13,7 @@ from neurotechdevkit.scenarios._metrics import (
     calculate_i_ta_target,
     calculate_mechanical_index,
 )
+from neurotechdevkit.results._results import SteadyStateResult2D
 
 CENTER_FREQUENCY = 1.5e6
 AMBIENT_PRESSURE = 2.5e6
@@ -25,7 +25,7 @@ DENSITY = 1200.0
 @pytest.fixture
 def patched_metric_fns(monkeypatch):
     """Stub metric functions to avoid depending on their implementation during tests"""
-    import neurotechdevkit.scenarios._metrics as metrics
+    import neurotechdevkit.results._metrics as metrics
 
     monkeypatch.setattr(
         metrics, "calculate_mechanical_index", lambda result, layer: 0.1234

--- a/tests/neurotechdevkit/scenarios/test_results.py
+++ b/tests/neurotechdevkit/scenarios/test_results.py
@@ -10,10 +10,9 @@ from neurotechdevkit.results import (
     PulsedResult3D,
     SteadyStateResult2D,
     SteadyStateResult3D,
-    create_pulsed_result,
-    create_steady_state_result,
 )
-from neurotechdevkit.scenarios import _metrics as metrics
+from neurotechdevkit.results import _metrics as metrics
+from neurotechdevkit.results import create_pulsed_result, create_steady_state_result
 
 
 @pytest.fixture


### PR DESCRIPTION
#### Introduction
As metrics are extracted from a Result object it makes sense to have them within the `results` folder
