### PR TITLE
Updating instructions for MacOS installation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,33 +36,85 @@ You also have to install stride, it can be done running:
 pip install git+https://github.com/trustimaging/stride
 ```
 
-`devito`, a dependency of `neurotechdevkit`, requires `libomp`. On MacOS it can be installed with:
 
-```
-brew install libomp
-```
+NDK uses [devito](https://www.devitoproject.org/devito/) to perform the heavy computational operations. Devito generates, compiles and runs C code to achieve better performance.
+The compiler used by Devito has to be selected, and paths for the linker might also be added as environment variables.
 
-the output of the command above will look like this:
-
-```
-For compilers to find libomp you may need to set:
-export LDFLAGS="-L/usr/local/opt/libomp/lib"
-export CPPFLAGS="-I/usr/local/opt/libomp/include"
-```
-
-`devito` requires the directory with `libomp` headers to be accessible during the runtime compilation, you can make it accessible by exporting a new environment variable `CPATH` with the path for libomp headers, like so:
-
-```
-export CPATH="/usr/local/opt/libomp/include"
-```
-
-You will also have to set an environment variable that defines what compiler `devito` will use, like so:
+Export the environment variable that defines what compiler `devito` will use:
 
 ```
 export DEVITO_ARCH=gcc
 ```
 
-the supported values for `DEVITO_ARCH` are: `'custom', 'gnu', 'gcc', 'clang', 'aomp', 'pgcc', 'pgi', 'nvc', 'nvc++', 'nvidia', 'cuda', 'osx', 'intel', 'icpc', 'icc', 'intel-knl', 'knl', 'dpcpp', 'gcc-4.9', 'gcc-5', 'gcc-6', 'gcc-7', 'gcc-8', 'gcc-9', 'gcc-10', 'gcc-11'`
+The supported values for `DEVITO_ARCH` are: `'custom', 'gnu', 'gcc', 'clang', 'aomp', 'pgcc', 'pgi', 'nvc', 'nvc++', 'nvidia', 'cuda', 'osx', 'intel', 'icpc', 'icc', 'intel-knl', 'knl', 'dpcpp', 'gcc-4.9', 'gcc-5', 'gcc-6', 'gcc-7', 'gcc-8', 'gcc-9', 'gcc-10', 'gcc-11'`
+
+
+#### MacOS
+
+The two main compiler options for MacOS are **clang** and **gcc**.
+
+##### clang
+
+If you prefer to use **clang** you will have to install `libomp` and `llvm`, you will also have to export a few environment variables needed for the compiler.
+
+1. Install libomp
+
+    ```
+    brew install libomp
+    ```
+
+    the output of the command above will look like this:
+
+    ```
+    For compilers to find libomp you may need to set:
+    export LDFLAGS="-L/usr/local/opt/libomp/lib"
+    export CPPFLAGS="-I/usr/local/opt/libomp/include"
+    ```
+
+
+1. Export a new environment variable `CPATH` with the path for `libomp` headers, like so:
+
+    ```
+    export CPATH="/usr/local/opt/libomp/include"
+    ```
+
+1. Install `llvm`:
+
+    ```
+    brew install llvm
+    ```
+
+1. Export the following environment variables:
+
+    ```
+    export PATH="/usr/local/opt/llvm/bin:$PATH"
+    export LDFLAGS="-L/usr/local/opt/llvm/lib"
+    export CPPFLAGS="-I/usr/local/opt/llvm/include"
+    ```
+
+1. Export the `DEVITO_ARCH` environment variable
+
+    ```
+    export DEVITO_ARCH="clang"
+    ```
+
+##### gcc
+
+On MacOS the `gcc` executable is a symbolic link to `clang`, so by defining ~~DEVITO_ARCH=gcc~~ devito will try to add `gcc` flags to the `clang` compiler, and the compilation will most probably fail.
+
+You can tell devito to use the correct gcc compiler doing the following:
+
+1. Install gcc-11
+
+    ```
+    brew install gcc@11
+    ```
+
+1. Export the `DEVITO_ARCH` environment variable
+
+    ```
+    export DEVITO_ARCH="gcc-11"
+    ```
 
 ### Docker
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,8 @@ markdown_extensions:
   - pymdownx.mark
   - attr_list
   - md_in_html
+  - pymdownx.tilde
+
 
 plugins:
   - gallery:


### PR DESCRIPTION
After getting the following error when running a 3D simulation:
```
Undefined symbols for architecture x86_64:
  "_omp_get_thread_num", referenced from:
      _acoustic_iso_state in eb9e3f74a93b6949c2bedccf28c75a01c539ee0d-c5907e.o
ld: symbol(s) not found for architecture x86_64
```
we've come up with new instructions on how to properly install NDK's dependencies into MacOS