### PR TITLE
Adding cronjob triggering circleCI to build the gallery examples without cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,19 @@
 # Tagging a commit with [circle front] will build the front page and perform tests-doc.
 # Tagging a commit with [circle full] will build everything.
 version: 2.1
+parameters:
+  GHA_Actor:
+    type: string
+    default: ""
+  GHA_Action:
+    type: string
+    default: ""
+  GHA_Event:
+    type: string
+    default: ""
+  GHA_Meta:
+    type: string
+    default: ""
 
 jobs:
   build_docs:
@@ -45,8 +58,41 @@ jobs:
           path: site/
           destination: html
 
+
+  build_docs_no_cache:
+    docker:
+      - image: cimg/python:3.10.10
+    resource_class: xlarge
+    steps:
+      - checkout
+
+      - run:
+          name: Install the latest version of Poetry
+          command: |
+            curl -sSL https://install.python-poetry.org | python3 -
+
+      - run:
+          name: Install dependencies
+          command: |
+            poetry install --no-ansi
+
+      - run:
+          name: Install stride
+          command: |
+            poetry run pip install git+https://github.com/trustimaging/stride
+
+      - run:
+          name: Build HTML
+          command: |
+            OFFLINE=true make docs
+
 workflows:
   version: 2
+
+  build_triggered_by_github_action:
+    when: << pipeline.parameters.GHA_Action >>
+    jobs:
+      - build_docs_no_cache
 
   default:
     jobs:

--- a/.github/workflows/trigger_gallery_build.yml
+++ b/.github/workflows/trigger_gallery_build.yml
@@ -1,0 +1,14 @@
+name: "Trigger gallery build"
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+
+jobs:
+  trigger-circleci:
+    name: "Trigger gallery build on CircleCI"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger circleCI
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.1.0
+        env:
+          CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}

--- a/.github/workflows/trigger_gallery_build.yml
+++ b/.github/workflows/trigger_gallery_build.yml
@@ -1,7 +1,10 @@
 name: "Trigger gallery build"
 on:
-  schedule:
-    - cron: '*/30 * * * *'
+  # schedule:
+  #   - cron: '*/30 * * * *'
+  pull_request:
+    branches:
+      - "*"
 
 jobs:
   trigger-circleci:

--- a/.github/workflows/trigger_gallery_build.yml
+++ b/.github/workflows/trigger_gallery_build.yml
@@ -1,10 +1,7 @@
 name: "Trigger gallery build"
 on:
-  # schedule:
-  #   - cron: '*/30 * * * *'
-  pull_request:
-    branches:
-      - "*"
+  schedule:
+    - cron: '0 7 * * 1' # every Monday 7am
 
 jobs:
   trigger-circleci:


### PR DESCRIPTION
Scheduling an action to trigger a circleCI build of the whole gallery

Triggered build: https://app.circleci.com/pipelines/github/agencyenterprise/neurotechdevkit/341/workflows/928a9dbf-dc2e-447b-bbda-cab93f5efb9b/jobs/277