### PR TITLE
Time-reverse simulation for phased-array delay design

### DIFF
--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -157,7 +157,7 @@ steady_state_result.render_steady_state_amplitudes()
 
 # %%
 # We want to visualize and find the maximum pressure within the brain, so let's
-# mask out everythig else.
+# mask out everything else.
 steady_state_pressure = steady_state_result.get_steady_state()
 # Only consider the brain region
 steady_state_pressure[~true_scenario.get_layer_mask("brain")] = np.nan
@@ -174,10 +174,12 @@ max_pressure_idx = np.unravel_index(max_pressure_flat_idx, steady_state_pressure
 max_pressure_idx
 
 grid = steady_state_result.traces.grid.space.grid
-focal_point = np.array([
-    grid[0][max_pressure_idx[0]],
-    grid[1][max_pressure_idx[1]],
-])
+focal_point = np.array(
+    [
+        grid[0][max_pressure_idx[0]],
+        grid[1][max_pressure_idx[1]],
+    ]
+)
 # The backend grid is in different coordinates from the scenario grid, so we
 # need to shift it.
 focal_point += true_scenario.origin

--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -65,6 +65,7 @@ true_scenario.render_layout()
 # %%
 # ## Simulate the time-reverse scenario
 # Place a point source at the original target, and simulate a pulse.
+# The point source is visualized as a gray dot.
 
 # Reinitialize the scenario
 reversed_scenario = ndk.make(SCENARIO_NAME)

--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -196,6 +196,11 @@ print("error [mm]:", error_distance * 1000)
 # The time-reverse simulation is not an exact solution for the forward-time
 # design. Other factors, like the angle of incidence at the boundary of two
 # materials, will be different in the time reverse vs forward-time.
+#
+# ### Exercise
+# Do you think the time-reverse simulation will work better or worse for deeper
+# targets? How about if the transducer was positioned next to a different part
+# of the skull that is flatter?
 
 
 # %%

--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+"""
+Time-reverse simulation for phased array
+====================================================================
+
+The skull adds aberrations to the beam propagation; phased arrays can compensate
+for those by having different delays for each element, but estimating these
+delays can be challenging. One method shared by Sergio Jiménez-Gambín and
+Samuel Blackman is to run a "time reverse" simulation to calculate the
+necessary delays.
+
+This notebook shows an example of a "time reverse" simulation. The notebook
+sets up a scenario with a phased array source and a target and then runs
+a simulation with the source and target reversed to calculate the delays.
+Finally, it uses the calculated delays to perform a forward-time simulation.
+
+Note: In this notebook, we refer to the "true" target as the eventual brain
+region we would like to stimulate, and the "true" source as the placement of
+the ultrasound probes. We refer to the "reversed" or "simulated" target and
+point-source as the values defined in our simulation, which are reversed from
+the physical setup to help calculate values.
+"""
+
+# %%
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import neurotechdevkit as ndk
+
+# Parameters
+SCENARIO_NAME = "scenario-2-2d-v0"
+NUM_ELEMENTS = 20
+ELEMENT_WIDTH = 1.2e-3
+
+
+# %%
+# Helper function to make the scenario with a PhasedArraySource
+def make_scenario(element_delays=None) -> ndk.scenarios.Scenario:
+    true_scenario = ndk.make(SCENARIO_NAME)
+
+    # define a phased-array source
+    default_source = true_scenario.get_default_source()
+    true_source = ndk.sources.PhasedArraySource2D(
+        element_delays=element_delays,
+        position=default_source.position,
+        direction=default_source.unit_direction,
+        num_elements=NUM_ELEMENTS,
+        pitch=default_source.aperture / NUM_ELEMENTS,
+        element_width=ELEMENT_WIDTH,
+        num_points=1000,
+    )
+
+    true_scenario.add_source(true_source)
+    return true_scenario
+
+
+# %%
+# ## Set up and visualize the forward scenario
+true_scenario = make_scenario()
+assert isinstance(true_scenario, ndk.scenarios.Scenario2D)
+true_scenario.render_layout()
+
+
+# %%
+# ## Simulate the time-reverse scenario
+# Place a point source at the original target, and simulate a pulse.
+
+# Reinitialize the scenario
+reversed_scenario = ndk.make(SCENARIO_NAME)
+# and reverse the source
+point_source = ndk.sources.PointSource2D(
+    position=true_scenario.target.center,
+)
+reversed_scenario.add_source(point_source)
+
+assert isinstance(reversed_scenario, ndk.scenarios.Scenario2D)
+reversed_scenario.render_layout()
+
+
+# %%
+result = reversed_scenario.simulate_pulse()
+assert isinstance(result, ndk.results.PulsedResult2D)
+result.render_pulsed_simulation_animation()
+
+
+# %% Calculate the time-reverse delays
+# We calculate how long it took for the point-source pulse to reach each of
+# the true array elements. Here, we coarsely approximate these delays by
+# finding the pressure argmax at each element's nearest-neighbor coordinates.
+
+# Map array elements onto the nearest pixels in our simulation
+def map_coordinates_to_indices(coordinates, origin, dx):
+    indices = np.round((coordinates - origin) / dx).astype(int)
+    return indices
+
+
+# Get the pressure time-series of these elements
+[true_source] = true_scenario.sources
+assert isinstance(true_source, ndk.sources.PhasedArraySource2D)
+element_indices = map_coordinates_to_indices(
+    true_source.element_positions,
+    reversed_scenario.origin,
+    reversed_scenario.dx,
+)
+pressure_at_elements = result.wavefield[element_indices[:, 0], element_indices[:, 1]]
+
+# Calculate the time of arrival for each element
+element_reverse_delays = np.argmax(pressure_at_elements, axis=1) * result.effective_dt
+plt.plot(element_reverse_delays, marker="o")
+plt.xlabel("element index")
+plt.ylabel("delay [s]")
+
+
+# %%
+# Visually inspecting the earlier scenario layout, these results seem reasonable.
+# The expected delay $$t_d$$ is approximately:
+#
+# $$t_d \approx \frac{||x_{source} - x_{target}||_2}{c_{water}} \approx \
+# \frac{0.07 \text{ m}}{1500 \text{ m/s}} \approx 47 \mu s$$
+#
+
+
+# %%
+# ## Use delays in forward-time simulation
+# Next, let's validate these delays by using them in a normal forward-time
+# simulation.
+# We simulate the original scenario, setting the pulse delays as calculated.
+
+# Elements that took longer to reach should now be pulsed first,
+# so we invert the values
+element_delays = element_reverse_delays.max() - element_reverse_delays
+
+true_scenario = make_scenario(element_delays=element_delays)
+result = true_scenario.simulate_pulse()
+assert isinstance(result, ndk.results.PulsedResult2D)
+result.render_pulsed_simulation_animation()
+
+
+# %%
+# The pulse should focus on the true target.
+
+
+# %%
+# ### Simulate steady-state
+# Another way to visualize the simulation is to check that the steady-state
+# pressure (within the skull) peaks near the target.
+
+# Re-initialize scenario to clear previous simulation
+true_scenario = make_scenario(element_delays=element_delays)
+steady_state_result = true_scenario.simulate_steady_state()
+assert isinstance(steady_state_result, ndk.results.SteadyStateResult2D)
+steady_state_result.render_steady_state_amplitudes()
+
+
+# %%
+# ## Future directions for improvement
+# The time-reverse simulation is not an exact solution for the forward-time
+# design. Other factors, like the angle of incidence at the boundary of two
+# materials, will be different in the time reverse vs forward-time.

--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -156,6 +156,40 @@ steady_state_result.render_steady_state_amplitudes()
 
 
 # %%
+# We want to visualize and find the maximum pressure within the brain, so let's
+# mask out everythig else.
+steady_state_pressure = steady_state_result.get_steady_state()
+# Only consider the brain region
+steady_state_pressure[~true_scenario.get_layer_mask("brain")] = np.nan
+steady_state_result.steady_state = steady_state_pressure
+
+steady_state_result.render_steady_state_amplitudes()
+
+
+# %%
+# We can also calculate how far the "time reverse" estimate is from the true
+# target.
+max_pressure_flat_idx = np.nanargmax(steady_state_pressure)
+max_pressure_idx = np.unravel_index(max_pressure_flat_idx, steady_state_pressure.shape)
+max_pressure_idx
+
+grid = steady_state_result.traces.grid.space.grid
+focal_point = np.array([
+    grid[0][max_pressure_idx[0]],
+    grid[1][max_pressure_idx[1]],
+])
+# The backend grid is in different coordinates from the scenario grid, so we
+# need to shift it.
+focal_point += true_scenario.origin
+
+print("target center:", true_scenario.target.center)
+print("beam focal point:", focal_point)
+error_distance = np.linalg.norm(true_scenario.target.center - focal_point)
+print("error [m]:", error_distance)
+print("error [mm]:", error_distance * 1000)
+
+
+# %%
 # ## Reasons for target mismatch
 # The time-reverse simulation is not an exact solution for the forward-time
 # design. Other factors, like the angle of incidence at the boundary of two

--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -64,7 +64,7 @@ true_scenario.render_layout()
 
 # %%
 # ## Simulate the time-reverse scenario
-# Place a point source at the original target, and simulate a pulse.
+# Place a point source at the true target, and simulate a pulse.
 # The point source is visualized as a gray dot.
 
 # Reinitialize the scenario

--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -115,10 +115,12 @@ plt.ylabel("delay [s]")
 
 # %%
 # Visually inspecting the earlier scenario layout, these results seem reasonable.
-# The expected delay $$t_d$$ is approximately:
+# The expected delay \(t_d\) is approximately:
 #
-# $$t_d \approx \frac{||x_{source} - x_{target}||_2}{c_{water}} \approx \
-# \frac{0.07 \text{ m}}{1500 \text{ m/s}} \approx 47 \mu s$$
+# $$
+# t_d \approx \frac{||x_{source} - x_{target}||_2}{c_{water}} \approx
+# \frac{0.07 \text{ m}}{1500 \text{ m/s}} \approx 47 \mu s
+# $$
 #
 
 

--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -5,13 +5,12 @@ Time-reverse simulation for phased array
 
 The skull adds aberrations to the beam propagation; phased arrays can compensate
 for those by having different delays for each element, but estimating these
-delays can be challenging. One method shared by Sergio Jiménez-Gambín and
-Samuel Blackman is to run a "time reverse" simulation to calculate the
-necessary delays.
-
-This notebook shows an example of a "time reverse" simulation. The notebook
-sets up a scenario with a phased array source and a target and then runs
-a simulation with the source and target reversed to calculate the delays.
+delays can be challenging.
+One method to estimate the delays is a "time reverse" simulation:
+https://koreascience.kr/article/JAKO200612242715181.pdf
+This notebook demonstrates the "time reverse" method to estimate the delays. The
+notebook sets up a scenario with a phased array source and a target and then
+runs a simulation with the source and target reversed to calculate the delays.
 Finally, it uses the calculated delays to perform a forward-time simulation.
 
 Note: In this notebook, we refer to the "true" target as the eventual brain
@@ -157,7 +156,13 @@ steady_state_result.render_steady_state_amplitudes()
 
 
 # %%
-# ## Future directions for improvement
+# ## Reasons for target mismatch
 # The time-reverse simulation is not an exact solution for the forward-time
 # design. Other factors, like the angle of incidence at the boundary of two
 # materials, will be different in the time reverse vs forward-time.
+
+
+# %%
+# ### Acknowledgments
+# Thanks to Sergio Jiménez-Gambín and Samuel Blackman for pointing us to the
+# "time reverse" simulation method.

--- a/docs/javascript/mathjax.js
+++ b/docs/javascript/mathjax.js
@@ -1,0 +1,17 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};
+
+document$.subscribe(() => {
+  MathJax.typesetPromise()
+})
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,11 @@ nav:
 extra_css:
 - css/mkdocstrings.css
 
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
 markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true

--- a/src/neurotechdevkit/rendering/__init__.py
+++ b/src/neurotechdevkit/rendering/__init__.py
@@ -6,7 +6,7 @@ from ._animations import (
     save_animation,
     video_only_output,
 )
-from ._source import SourceType
+from ._source import SourceRenderType
 from .layers import (
     SourceDrawingParams,
     draw_material_outlines,
@@ -41,7 +41,7 @@ __all__ = [
     "make_animation",
     "video_only_output",
     "display_video_file",
-    "SourceType",
+    "SourceRenderType",
     "configure_matplotlib_for_embedded_animation",
     "save_animation",
 ]

--- a/src/neurotechdevkit/rendering/__init__.py
+++ b/src/neurotechdevkit/rendering/__init__.py
@@ -6,7 +6,7 @@ from ._animations import (
     save_animation,
     video_only_output,
 )
-from ._source import source_should_be_flat, source_should_be_point
+from ._source import SourceType
 from .layers import (
     SourceDrawingParams,
     draw_material_outlines,
@@ -41,8 +41,7 @@ __all__ = [
     "make_animation",
     "video_only_output",
     "display_video_file",
-    "source_should_be_flat",
-    "source_should_be_point",
+    "SourceType",
     "configure_matplotlib_for_embedded_animation",
     "save_animation",
 ]

--- a/src/neurotechdevkit/rendering/__init__.py
+++ b/src/neurotechdevkit/rendering/__init__.py
@@ -6,7 +6,7 @@ from ._animations import (
     save_animation,
     video_only_output,
 )
-from ._source import source_should_be_flat
+from ._source import source_should_be_flat, source_should_be_point
 from .layers import (
     SourceDrawingParams,
     draw_material_outlines,
@@ -42,6 +42,7 @@ __all__ = [
     "video_only_output",
     "display_video_file",
     "source_should_be_flat",
+    "source_should_be_point",
     "configure_matplotlib_for_embedded_animation",
     "save_animation",
 ]

--- a/src/neurotechdevkit/rendering/_source.py
+++ b/src/neurotechdevkit/rendering/_source.py
@@ -223,8 +223,7 @@ def _load_most_similar_source_image(
         aperture: the aperture of the source (in meters).
         focal_length: the focal length of the source (in meters). For planar sources,
             this value should equal np.inf.
-        source_type: SourceType enum boolean indicating how the source should be
-            represented.
+        source_type: SourceType indicating how the source should be represented.
 
     Returns:
         A numpy array containing the source image data.
@@ -274,8 +273,7 @@ def _select_image_file(
         aperture: the aperture of the source (in meters).
         focal_length: the focal length of the source (in meters). For planar sources,
             this value should equal np.inf.
-        source_type: SourceType enum boolean indicating how the source should be
-            represented.
+        source_type: SourceType indicating how the source should be represented.
 
     Returns:
         The path to the file containing the selected image.

--- a/src/neurotechdevkit/results/_results.py
+++ b/src/neurotechdevkit/results/_results.py
@@ -375,7 +375,7 @@ class SteadyStateResult3D(SteadyStateResult):
                     direction=drop_element(source.unit_direction, slice_axis),
                     aperture=source.aperture,
                     focal_length=source.focal_length,
-                    source_type=rendering.SourceType.from_source(source),
+                    source_type=rendering.SourceRenderType.from_source(source),
                 )
                 rendering.draw_source(ax, drawing_params)
 
@@ -1056,7 +1056,7 @@ class PulsedResult3D(PulsedResult):
                     direction=drop_element(source.unit_direction, slice_axis),
                     aperture=source.aperture,
                     focal_length=source.focal_length,
-                    source_type=rendering.SourceType.from_source(source),
+                    source_type=rendering.SourceRenderType.from_source(source),
                 )
                 rendering.draw_source(ax, drawing_params)
 

--- a/src/neurotechdevkit/results/_results.py
+++ b/src/neurotechdevkit/results/_results.py
@@ -281,6 +281,7 @@ class SteadyStateResult2D(SteadyStateResult):
                     aperture=source.aperture,
                     focal_length=source.focal_length,
                     source_is_flat=rendering.source_should_be_flat(source),
+                    is_point_source=rendering.source_should_be_point(source),
                 )
                 rendering.draw_source(ax, drawing_params)
 
@@ -382,6 +383,7 @@ class SteadyStateResult3D(SteadyStateResult):
                     aperture=source.aperture,
                     focal_length=source.focal_length,
                     source_is_flat=rendering.source_should_be_flat(source),
+                    is_point_source=rendering.source_should_be_point(source),
                 )
                 rendering.draw_source(ax, drawing_params)
 
@@ -780,6 +782,7 @@ class PulsedResult2D(PulsedResult):
                     aperture=source.aperture,
                     focal_length=source.focal_length,
                     source_is_flat=rendering.source_should_be_flat(source),
+                    is_point_source=rendering.source_should_be_point(source),
                 )
                 rendering.draw_source(ax, drawing_params)
 
@@ -1069,6 +1072,7 @@ class PulsedResult3D(PulsedResult):
                     aperture=source.aperture,
                     focal_length=source.focal_length,
                     source_is_flat=rendering.source_should_be_flat(source),
+                    is_point_source=rendering.source_should_be_point(source),
                 )
                 rendering.draw_source(ax, drawing_params)
 

--- a/src/neurotechdevkit/results/_results.py
+++ b/src/neurotechdevkit/results/_results.py
@@ -275,14 +275,7 @@ class SteadyStateResult2D(SteadyStateResult):
             )
         if show_sources:
             for source in self.scenario.sources:
-                drawing_params = rendering.SourceDrawingParams(
-                    position=source.position,
-                    direction=source.unit_direction,
-                    aperture=source.aperture,
-                    focal_length=source.focal_length,
-                    source_is_flat=rendering.source_should_be_flat(source),
-                    is_point_source=rendering.source_should_be_point(source),
-                )
+                drawing_params = rendering.SourceDrawingParams.from_source(source)
                 rendering.draw_source(ax, drawing_params)
 
         rendering.configure_result_plot(
@@ -382,8 +375,7 @@ class SteadyStateResult3D(SteadyStateResult):
                     direction=drop_element(source.unit_direction, slice_axis),
                     aperture=source.aperture,
                     focal_length=source.focal_length,
-                    source_is_flat=rendering.source_should_be_flat(source),
-                    is_point_source=rendering.source_should_be_point(source),
+                    source_type=rendering.SourceType.from_source(source),
                 )
                 rendering.draw_source(ax, drawing_params)
 
@@ -776,14 +768,7 @@ class PulsedResult2D(PulsedResult):
 
         if show_sources:
             for source in self.scenario.sources:
-                drawing_params = rendering.SourceDrawingParams(
-                    position=source.position,
-                    direction=source.unit_direction,
-                    aperture=source.aperture,
-                    focal_length=source.focal_length,
-                    source_is_flat=rendering.source_should_be_flat(source),
-                    is_point_source=rendering.source_should_be_point(source),
-                )
+                drawing_params = rendering.SourceDrawingParams.from_source(source)
                 rendering.draw_source(ax, drawing_params)
 
         rendering.configure_result_plot(
@@ -1071,8 +1056,7 @@ class PulsedResult3D(PulsedResult):
                     direction=drop_element(source.unit_direction, slice_axis),
                     aperture=source.aperture,
                     focal_length=source.focal_length,
-                    source_is_flat=rendering.source_should_be_flat(source),
-                    is_point_source=rendering.source_should_be_point(source),
+                    source_type=rendering.SourceType.from_source(source),
                 )
                 rendering.draw_source(ax, drawing_params)
 

--- a/src/neurotechdevkit/scenarios/_base.py
+++ b/src/neurotechdevkit/scenarios/_base.py
@@ -921,6 +921,7 @@ class Scenario2D(Scenario):
                     aperture=source.aperture,
                     focal_length=source.focal_length,
                     source_is_flat=rendering.source_should_be_flat(source),
+                    is_point_source=rendering.source_should_be_point(source),
                 )
                 rendering.draw_source(ax, drawing_params)
 
@@ -1101,6 +1102,7 @@ class Scenario3D(Scenario):
                     aperture=source.aperture,
                     focal_length=source.focal_length,
                     source_is_flat=rendering.source_should_be_flat(source),
+                    is_point_source=rendering.source_should_be_point(source),
                 )
                 rendering.draw_source(ax, drawing_params)
 

--- a/src/neurotechdevkit/scenarios/_base.py
+++ b/src/neurotechdevkit/scenarios/_base.py
@@ -1094,7 +1094,7 @@ class Scenario3D(Scenario):
                     direction=drop_element(source.unit_direction, slice_axis),
                     aperture=source.aperture,
                     focal_length=source.focal_length,
-                    source_type=rendering.SourceType.from_source(source),
+                    source_type=rendering.SourceRenderType.from_source(source),
                 )
                 rendering.draw_source(ax, drawing_params)
 

--- a/src/neurotechdevkit/scenarios/_base.py
+++ b/src/neurotechdevkit/scenarios/_base.py
@@ -915,14 +915,7 @@ class Scenario2D(Scenario):
         if show_sources:
             self._ensure_source()
             for source in self.sources:
-                drawing_params = rendering.SourceDrawingParams(
-                    position=source.position,
-                    direction=source.unit_direction,
-                    aperture=source.aperture,
-                    focal_length=source.focal_length,
-                    source_is_flat=rendering.source_should_be_flat(source),
-                    is_point_source=rendering.source_should_be_point(source),
-                )
+                drawing_params = rendering.SourceDrawingParams.from_source(source)
                 rendering.draw_source(ax, drawing_params)
 
         rendering.configure_layout_plot(
@@ -1101,8 +1094,7 @@ class Scenario3D(Scenario):
                     direction=drop_element(source.unit_direction, slice_axis),
                     aperture=source.aperture,
                     focal_length=source.focal_length,
-                    source_is_flat=rendering.source_should_be_flat(source),
-                    is_point_source=rendering.source_should_be_point(source),
+                    source_type=rendering.SourceType.from_source(source),
                 )
                 rendering.draw_source(ax, drawing_params)
 

--- a/src/neurotechdevkit/sources.py
+++ b/src/neurotechdevkit/sources.py
@@ -153,6 +153,90 @@ class Source(abc.ABC):
         pass
 
 
+class PointSource(Source):
+    """Theoretical point source.
+
+    Automatically sets `aperture`, `focal_length`, and `direction`, and `num_points`.
+    """
+
+    def __init__(
+        self,
+        *,
+        position: npt.NDArray[np.float_],
+        num_dim: int = 2,
+        delay: float = 0.0,
+    ) -> None:
+        """Initialize a new point source."""
+        super().__init__(
+            position=position,
+            direction=np.full(shape=num_dim, fill_value=np.nan),
+            aperture=0.0,
+            focal_length=0.0,
+            num_points=1,
+            delay=delay,
+        )
+
+    def _calculate_coordinates(self) -> npt.NDArray[np.float_]:
+        """Calculate the coordinates of the point source cloud for the 2D source.
+
+        Returns:
+            An array containing the coordinates (in meters) of the point source.
+        """
+        return np.array([self.position])
+
+    def calculate_waveform_scale(self, dx: float) -> float:
+        """Calculate the scale factor to apply to waveforms from point source.
+
+        The scale is equal to the ratio between the density of source points
+        and the density of grid points (2D: 1 / dx; 3D: 1 / dx**2).
+        Because the aperture is technically zero, we approximate the source
+        density as the smallest grid (2D: 1 / dx; 3D: 1 / dx**2).
+
+        Args:
+            dx: the separation between gridpoints (in meters). Assumed to be the same in
+                both directions.
+                Unused.
+
+        Returns:
+            The scale factor to apply to the waveform.
+        """
+        return 1
+
+
+class PointSource2D(PointSource):
+    """A point source in 2D."""
+
+    def __init__(
+        self,
+        *,
+        position: npt.NDArray[np.float_],
+        delay: float = 0.0,
+    ) -> None:
+        """Initialize a new 2-D point source."""
+        super().__init__(
+            position=position,
+            num_dim=2,
+            delay=delay,
+        )
+
+
+class PointSource3D(PointSource):
+    """A point source in 3D."""
+
+    def __init__(
+        self,
+        *,
+        position: npt.NDArray[np.float_],
+        delay: float = 0.0,
+    ) -> None:
+        """Initialize a new 2-D point source."""
+        super().__init__(
+            position=position,
+            num_dim=3,
+            delay=delay,
+        )
+
+
 class FocusedSource2D(Source):
     """A focused source in 2D.
 
@@ -393,8 +477,8 @@ class FocusedSource3D(Source):
         return axis, theta
 
 
-class UnfocusedSource(Source):
-    """A base class for unfocused sources.
+class UnfocusedSource(Source, abc.ABC):
+    """An abstract base class for unfocused sources.
 
     Automatically sets `focal_length` to `np.inf`
     """

--- a/tests/neurotechdevkit/test_sources.py
+++ b/tests/neurotechdevkit/test_sources.py
@@ -12,6 +12,8 @@ from neurotechdevkit.sources import (
     PhasedArraySource3D,
     PlanarSource2D,
     PlanarSource3D,
+    PointSource2D,
+    PointSource3D,
     _rotate_2d,
     _rotate_3d,
 )
@@ -1719,3 +1721,55 @@ class TestPhasedArraySource3D(Source3DTestMixin):
         grid_density = 1 / dx**2
         point_density = quotient * num_elements / (length * height)
         np.testing.assert_allclose(scale, grid_density / point_density)
+
+
+class TestPointSource2D:
+    def test_init_properties(self):
+        """Verify that .position and .delay match the value received in the
+        constructor.
+        """
+        position = np.array([-2.0, 3.0])
+        delay = 123
+        source = PointSource2D(position=position, delay=delay)
+        np.testing.assert_allclose(source.position, position)
+        assert source.delay == delay
+
+    def test_calculate_coordinates(self):
+        """Verify that the calculated coordinates match the specified position."""
+        position = np.array([-2.0, 3.0])
+        source = PointSource2D(position=position)
+        np.testing.assert_allclose(
+            source._calculate_coordinates(), np.array([position])
+        )
+
+    def test_calculate_waveform_scale(self):
+        """Verify that calculate_waveform_scale returns 1."""
+        dx = 0.01
+        source = PointSource2D(position=np.array([-2.0, 3.0]))
+        assert source.calculate_waveform_scale(dx=dx) == 1
+
+
+class TestPointSource3D:
+    def test_init_properties(self):
+        """Verify that .position and .delay match the value received in the
+        constructor.
+        """
+        position = np.array([1.0, -2.0, 3.0])
+        delay = 123
+        source = PointSource3D(position=position, delay=delay)
+        np.testing.assert_allclose(source.position, position)
+        assert source.delay == delay
+
+    def test_calculate_coordinates(self):
+        """Verify that the calculated coordinates match the specified position."""
+        position = np.array([1.0, -2.0, 3.0])
+        source = PointSource3D(position=position)
+        np.testing.assert_allclose(
+            source._calculate_coordinates(), np.array([position])
+        )
+
+    def test_calculate_waveform_scale(self):
+        """Verify that calculate_waveform_scale returns 1."""
+        dx = 0.01
+        source = PointSource3D(position=np.array([1.0, -2.0, 3.0]))
+        assert source.calculate_waveform_scale(dx=dx) == 1

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -25,6 +25,7 @@ downsampling
 dt
 dx
 eg
+Enum
 et
 ffmpeg
 fft


### PR DESCRIPTION
#### Introduction

https://github.com/agencyenterprise/neurotechdevkit/issues/95

The skull adds aberrations to to the beam propagation; phased arrays have the potential to compensate for those by having different delays for each element, but estimating these delays can be challenging. One method shared by Sergio Jiménez-Gambín and Samuel Blackman is to run a "time reverse" simulation to calculate the necessary delays.

A "time reverse" simulation puts a point source where you want to focus your phased array and measures delays for wavefront at the position of the elements of your array.

This pull request adds an example notebook that performs the "time reverse" simulation to calculate element delays. It then validates the calculated delays by performing a standard forward-time simulation.

#### Changes
* Add a new "time reverse" simulation notebook
* Add a `PointSource` class that implements a (hypothetical) single-point ultrasound transducer

##### Not complete:
* The plot legend for `PointSource` is still a transducer image.

#### Behavior

Run the `time_reverse_simulation.ipynb` notebook with different scenarios and target/source locations. The final `matplotlib` animation should show the ultrasound pulse focusing on the true target.

Pulsed simulation:
![pulsed_simulation](https://github.com/agencyenterprise/neurotechdevkit/assets/3221512/28d1ca6f-a1b9-40dc-82e2-d8a0aa470093)


Steady-state simulation:
![image](https://github.com/agencyenterprise/neurotechdevkit/assets/3221512/852bf832-50d0-4233-a618-1e5acded7eda)
