### PR TITLE
Add ffmpeg to docker dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ WORKDIR /ndk
 
 RUN ./venv/bin/pip install --upgrade pip
 
-RUN apt-get update && apt-get install -y g++ jq make unzip wget && \
+RUN apt-get update && \
+    apt-get install -y g++ jq make unzip wget ffmpeg && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Introduction
This pull request addresses https://github.com/agencyenterprise/neurotechdevkit/issues/106.

The issue describes a bug where running the plot_pulsed_simulation.ipynb example notebook from the prebuilt docker container results in an error when trying to create an animation video due to the missing ffmpeg dependency. This pull request adds ffmpeg to the docker dependencies to resolve the issue.

## Changes
The following changes have been made in this pull request:
* Added ffmpeg to the docker dependencies.

## Behavior
The new behavior introduced by this pull request is that the plot_pulsed_simulation.ipynb example notebook will now be able to create the animation.mp4 file successfully, as ffmpeg will be available in the docker container.

To test this change:

* Pull the latest version of the repository.
* Build and run the docker container: `docker build --tag 'ndk' . && docker run -i -t -p 8888:8888 -v $(pwd)/notebooks:/app/notebooks -it 'ndk'`
* Move the example notebook to the notebooks folder.
* Run the example notebook.
* Verify that the notebook successfully saves the animation.mp4 file.