### PR TITLE
Update `napari` install instructions to Qt6 on Mac M1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,7 @@ jobs:
         run: poetry run pip install git+https://github.com/trustimaging/stride
 
       - name: Install napari
-        run: poetry run pip install napari
+        run: poetry run pip install "napari[all,pyqt6_experimental]"
 
       - name: Install neurotechdevkit
         run: poetry install --only-root

--- a/docs/examples/plot_3d.py
+++ b/docs/examples/plot_3d.py
@@ -32,7 +32,8 @@ result = ndk.load_result_from_disk(downloaded_file_path)
 # pip install "napari[all]"
 # ```
 #
-# Note for Mac M1 users: Qt5 does not support Mac M1, so you will need to install the Qt6 backend instead:
+# Note for Mac M1 users: Qt5 does not support Mac M1, so you will need to
+# install the Qt6 backend instead:
 # ```
 # pip install "napari[pyqt6_experimental]"
 # ```

--- a/docs/examples/plot_3d.py
+++ b/docs/examples/plot_3d.py
@@ -32,7 +32,12 @@ result = ndk.load_result_from_disk(downloaded_file_path)
 # pip install "napari[all]"
 # ```
 #
-# or by following the `napari` installation instructions
+# Note for Mac M1 users: Qt5 does not support Mac M1, so you will need to install the Qt6 backend instead:
+# ```
+# pip install "napari[pyqt6_experimental]"
+# ```
+#
+# You can also follow the `napari` installation instructions:
 # [link](https://napari.org/stable/tutorials/fundamentals/installation.html).
 
 try:

--- a/docs/usage/troubleshooting.md
+++ b/docs/usage/troubleshooting.md
@@ -78,4 +78,6 @@ This error is shown when napari is not installed, make sure to run
 
   `pip install "napari[all]"`
 
+(or `pip install "napari[pyqt6_experimental]"` if running on a Mac M1)
+
 and try again.

--- a/src/neurotechdevkit/rendering/napari.py
+++ b/src/neurotechdevkit/rendering/napari.py
@@ -112,7 +112,7 @@ def _create_napari_3d(
             " experimental and is not included as an explicit dependency of NDK."
             ' Please install via `pip install "napari[all]"` or"'
             ' `pip install "napari[pyqt6_experimental]"` or'
-            " follow napari\'s' instructions at:"
+            " follow napari's' instructions at:"
             " https://napari.org/stable/tutorials/fundamentals/installation.html"
         ) from e
 

--- a/src/neurotechdevkit/rendering/napari.py
+++ b/src/neurotechdevkit/rendering/napari.py
@@ -111,7 +111,7 @@ def _create_napari_3d(
             "3D rendering requires napari to be installed. Integration with napari is"
             " experimental and is not included as an explicit dependency of NDK."
             ' Please install via `pip install "napari[all]"` or"'
-            ' `pip install "napari[pyqt6_experimental]"` or'
+            ' `pip install "napari[pyqt6_experimental]" if running on a Mac M1` or'
             " follow napari's' instructions at:"
             " https://napari.org/stable/tutorials/fundamentals/installation.html"
         ) from e

--- a/src/neurotechdevkit/rendering/napari.py
+++ b/src/neurotechdevkit/rendering/napari.py
@@ -110,8 +110,9 @@ def _create_napari_3d(
         raise ImportError(
             "3D rendering requires napari to be installed. Integration with napari is"
             " experimental and is not included as an explicit dependency of NDK."
-            ' Please install via `pip install "napari[all]"` or follow napari\'s'
-            " instructions at:"
+            ' Please install via `pip install "napari[all]"` or"'
+            ' `pip install "napari[pyqt6_experimental]"` or'
+            " follow napari\'s' instructions at:"
             " https://napari.org/stable/tutorials/fundamentals/installation.html"
         ) from e
 


### PR DESCRIPTION
#### Introduction

https://github.com/agencyenterprise/neurotechdevkit/issues/119

`napari` is an optional dependency for 3D visualizations. The instructions use `napari[all]`, which installs `PyQt5` GUI backend, but `Qt5` is not supported on Mac M1.

#### Changes

This updates the documentation to install `napari` with `PyQt6` on Mac M1.

#### Behavior

`plot_3d.py` can run on a Mac M1 after following documentation instructions to `pip install "napari[pyqt6_experimental]"`. Tested by running on my Mac M1. Screenshot:

<img width="1075" alt="image" src="https://github.com/agencyenterprise/neurotechdevkit/assets/3221512/c03dc662-7ad8-41d2-97a8-abf96bb123ca">

