### PR TITLE
fix typo: type-hint vs default-value

### DIFF
--- a/src/neurotechdevkit/scenarios/_scenario_0.py
+++ b/src/neurotechdevkit/scenarios/_scenario_0.py
@@ -58,7 +58,7 @@ class Scenario0(Scenario2D):
             for name in self.material_layers
         }
 
-    def _compile_problem(self, center_frequency=float) -> stride.Problem:
+    def _compile_problem(self, center_frequency: float) -> stride.Problem:
         extent = np.array([0.05, 0.04])  # m
         origin = self.origin  # m
 


### PR DESCRIPTION
#### Introduction

Noticed there was a typo with the type-hint being written as a default value:
```python
    def _compile_problem(self, center_frequency=float) -> stride.Problem:
```

#### Changes

Changed to type hint (same as other scenarios):
```python
    def _compile_problem(self, center_frequency: float) -> stride.Problem:
```
