### PR TITLE
Not adding default labels if PR is already labeled

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,16 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    if: >
+      ${{
+        !(
+          github.event.label.name == 'release:patch' ||
+          github.event.label.name == 'release:minor' ||
+          github.event.label.name == 'release:major' ||
+          github.event.label.name == 'norelease' ||
+          github.event.label.name == 'label_review'
+        )
+      }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,7 @@ name: "Pull Request Labeler"
 
 on:
   pull_request:
+    types: [opened]
     branches:
       - "*"
 
@@ -10,16 +11,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: >
-      ${{
-        !(
-          github.event.label.name == 'release:patch' ||
-          github.event.label.name == 'release:minor' ||
-          github.event.label.name == 'release:major' ||
-          github.event.label.name == 'norelease' ||
-          github.event.label.name == 'label_review'
-        )
-      }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -97,8 +97,8 @@ Before opening a pull request, please make sure that all of the following requir
 1. type hinting is used on all function and method parameters and return values, excluding tests
 1. docstring usage conforms to the following:
       1. all docstrings should follow [PEP257 Docstring Conventions](https://peps.python.org/pep-0257/)
-      2. all public API classes, functions, methods, and properties have docstrings and follow the [Google Python Style Guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)
-      3. docstrings on private objects are not required, but are encouraged where they would significantly aid understanding
+      1. all public API classes, functions, methods, and properties have docstrings and follow the [Google Python Style Guide](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)
+      1. docstrings on private objects are not required, but are encouraged where they would significantly aid understanding
 1. testing is done using the pytest library, and test coverage should not unnecessarily decrease.
 
 


### PR DESCRIPTION
#### Introduction
There's a bug with the labeler workflow, it always adds the default `label_review` and `release:patch` even if other labels were already assigned to the PR.

#### Changes
This PR adds a condition to run the labeler, not adding the default labels if labels were already assigned to the PR