### PR TITLE
Fix slice index for benchmark-8 2D

### DIFF
--- a/src/neurotechdevkit/scenarios/built_in/_scenario_2.py
+++ b/src/neurotechdevkit/scenarios/built_in/_scenario_2.py
@@ -281,7 +281,7 @@ def _create_scenario_2_mask(material, convert_2d=False) -> npt.NDArray[np.bool_]
         raise ValueError(material)
 
     if convert_2d:
-        mask = mask[:, :, 185]
+        mask = mask[:, :, 190]
         # slice through the center of the transducer
 
     return mask


### PR DESCRIPTION
#### Introduction

Scenario 2 is based on benchmark 8 of [Aubry et al. (2022)](https://pubs.aip.org/asa/jasa/article/152/2/1003/2838380/Benchmark-problems-for-transcranial-ultrasound). NDK provides a 2D variant that is supposed to correspond to the slice through the transducer.

#### Changes

Fixes the slice index for benchmark 8's 2D variant to match the paper description:

> Using 1-based indexing, the center of the source (rear of the bowl or center of the piston) relative to the output grid was positioned at... [1, 171, 191] for benchmark 8.

This also happens to be the middle slice: `.shape[2] // 2`. The 3-D `mask.shape` is `(451, 341, 381)`


TODO:
- [x] re-direct this PR towards `main` once https://github.com/agencyenterprise/neurotechdevkit/pull/122 lands.
