### PR TITLE
134 Slice `SteadyStateResult3D` to `SteadyStateResult2D`

### DIFF
--- a/src/neurotechdevkit/results/_metrics.py
+++ b/src/neurotechdevkit/results/_metrics.py
@@ -159,7 +159,7 @@ def calculate_focal_gain(result: results.SteadyStateResult) -> float:
     Returns:
         The focal gain (in dB)
     """
-    if not hasattr(result.scenario, "_target"):
+    if result.scenario.get_target_mask() is None:
         print(
             "WARNING: No target was specified in the scenario. "
             "Not calculating focal gain."
@@ -216,7 +216,7 @@ def calculate_i_ta_target(result: results.SteadyStateResult) -> float:
     Returns:
         the time-averaged intensity averaged over the target region (in W/m^2).
     """
-    if not hasattr(result.scenario, "_target"):
+    if result.scenario.get_target_mask() is None:
         print(
             "WARNING: No target was specified in the scenario. "
             "Not calculating time-averaged intensity in target."
@@ -252,7 +252,7 @@ def calculate_i_ta_off_target(result: results.SteadyStateResult) -> float:
         the time-averaged intensity averaged over the brain but outside of the target
             region (in W/m^2).
     """
-    if not hasattr(result.scenario, "_target"):
+    if result.scenario.get_target_mask() is None:
         print(
             "WARNING: No target was specified in the scenario. "
             "Not calculating time-averaged intensity off target."
@@ -282,7 +282,7 @@ def calculate_i_pa_target(result: results.SteadyStateResult) -> float:
     Returns:
         the pulse-averaged intensity averaged over the target region (in W/m^2).
     """
-    if not hasattr(result.scenario, "_target"):
+    if result.scenario.get_target_mask() is None:
         print(
             "WARNING: No target was specified in the scenario. "
             "Not calculating pulse-averaged intensity in target."
@@ -310,7 +310,7 @@ def calculate_i_pa_off_target(result: results.SteadyStateResult) -> float:
         the pulse-averaged intensity averaged over the brain but outside of the target
             region (in W/m^2).
     """
-    if not hasattr(result.scenario, "_target"):
+    if result.scenario.get_target_mask() is None:
         print(
             "WARNING: No target was specified in the scenario. "
             "Not calculating pulse-averaged intensity off target."

--- a/src/neurotechdevkit/results/_metrics.py
+++ b/src/neurotechdevkit/results/_metrics.py
@@ -159,12 +159,6 @@ def calculate_focal_gain(result: results.SteadyStateResult) -> float:
     Returns:
         The focal gain (in dB)
     """
-    if result.scenario.get_target_mask() is None:
-        print(
-            "WARNING: No target was specified in the scenario. "
-            "Not calculating focal gain."
-        )
-        return None
     target_mask = result.scenario.get_target_mask()
     brain_mask = result.scenario.material_masks["brain"]
 
@@ -216,12 +210,6 @@ def calculate_i_ta_target(result: results.SteadyStateResult) -> float:
     Returns:
         the time-averaged intensity averaged over the target region (in W/m^2).
     """
-    if result.scenario.get_target_mask() is None:
-        print(
-            "WARNING: No target was specified in the scenario. "
-            "Not calculating time-averaged intensity in target."
-        )
-        return None
     target_mask = result.scenario.get_target_mask()
     i_spta = calculate_i_ta(result)
     i_spta_in_target: npt.NDArray[np.float_] = np.ma.masked_array(
@@ -252,12 +240,6 @@ def calculate_i_ta_off_target(result: results.SteadyStateResult) -> float:
         the time-averaged intensity averaged over the brain but outside of the target
             region (in W/m^2).
     """
-    if result.scenario.get_target_mask() is None:
-        print(
-            "WARNING: No target was specified in the scenario. "
-            "Not calculating time-averaged intensity off target."
-        )
-        return None
     target_mask = result.scenario.get_target_mask()
     brain_mask = result.scenario.material_masks["brain"]
 
@@ -282,12 +264,6 @@ def calculate_i_pa_target(result: results.SteadyStateResult) -> float:
     Returns:
         the pulse-averaged intensity averaged over the target region (in W/m^2).
     """
-    if result.scenario.get_target_mask() is None:
-        print(
-            "WARNING: No target was specified in the scenario. "
-            "Not calculating pulse-averaged intensity in target."
-        )
-        return None
     return calculate_i_ta_target(result)
 
 
@@ -310,12 +286,6 @@ def calculate_i_pa_off_target(result: results.SteadyStateResult) -> float:
         the pulse-averaged intensity averaged over the brain but outside of the target
             region (in W/m^2).
     """
-    if result.scenario.get_target_mask() is None:
-        print(
-            "WARNING: No target was specified in the scenario. "
-            "Not calculating pulse-averaged intensity off target."
-        )
-        return None
     return calculate_i_ta_off_target(result)
 
 
@@ -350,9 +320,6 @@ class Conversions:
         Returns:
             The converted value.
         """
-        if value is None:
-            return None
-
         if from_uom == "W/m²" and to_uom == "mW/cm²":
             return value * 0.1
 

--- a/src/neurotechdevkit/results/_metrics.py
+++ b/src/neurotechdevkit/results/_metrics.py
@@ -159,6 +159,12 @@ def calculate_focal_gain(result: results.SteadyStateResult) -> float:
     Returns:
         The focal gain (in dB)
     """
+    if not hasattr(result.scenario, "_target"):
+        print(
+            "WARNING: No target was specified in the scenario. "
+            "Not calculating focal gain."
+        )
+        return None
     target_mask = result.scenario.get_target_mask()
     brain_mask = result.scenario.material_masks["brain"]
 
@@ -210,6 +216,12 @@ def calculate_i_ta_target(result: results.SteadyStateResult) -> float:
     Returns:
         the time-averaged intensity averaged over the target region (in W/m^2).
     """
+    if not hasattr(result.scenario, "_target"):
+        print(
+            "WARNING: No target was specified in the scenario. "
+            "Not calculating time-averaged intensity in target."
+        )
+        return None
     target_mask = result.scenario.get_target_mask()
     i_spta = calculate_i_ta(result)
     i_spta_in_target: npt.NDArray[np.float_] = np.ma.masked_array(
@@ -240,6 +252,12 @@ def calculate_i_ta_off_target(result: results.SteadyStateResult) -> float:
         the time-averaged intensity averaged over the brain but outside of the target
             region (in W/m^2).
     """
+    if not hasattr(result.scenario, "_target"):
+        print(
+            "WARNING: No target was specified in the scenario. "
+            "Not calculating time-averaged intensity off target."
+        )
+        return None
     target_mask = result.scenario.get_target_mask()
     brain_mask = result.scenario.material_masks["brain"]
 
@@ -264,6 +282,12 @@ def calculate_i_pa_target(result: results.SteadyStateResult) -> float:
     Returns:
         the pulse-averaged intensity averaged over the target region (in W/m^2).
     """
+    if not hasattr(result.scenario, "_target"):
+        print(
+            "WARNING: No target was specified in the scenario. "
+            "Not calculating pulse-averaged intensity in target."
+        )
+        return None
     return calculate_i_ta_target(result)
 
 
@@ -286,6 +310,12 @@ def calculate_i_pa_off_target(result: results.SteadyStateResult) -> float:
         the pulse-averaged intensity averaged over the brain but outside of the target
             region (in W/m^2).
     """
+    if not hasattr(result.scenario, "_target"):
+        print(
+            "WARNING: No target was specified in the scenario. "
+            "Not calculating pulse-averaged intensity off target."
+        )
+        return None
     return calculate_i_ta_off_target(result)
 
 
@@ -320,6 +350,9 @@ class Conversions:
         Returns:
             The converted value.
         """
+        if value is None:
+            return None
+
         if from_uom == "W/m²" and to_uom == "mW/cm²":
             return value * 0.1
 

--- a/src/neurotechdevkit/results/_results.py
+++ b/src/neurotechdevkit/results/_results.py
@@ -424,49 +424,6 @@ class SteadyStateResult3D(SteadyStateResult):
         """
         rendering.render_amplitudes_3d_with_napari(self)
 
-    def _validate_slice_args(
-        self, slice_axis: int | None, slice_position: float | None
-    ) -> None:
-        """Validate that slicing axis and position are within scenario range.
-
-        `slice_axis` should be either 0, 1, or 2 (for X, Y, Z).
-        `slice_position` must be within boundaries for `slice_axis` extent.
-
-        Args:
-            slice_axis: the axis along which to slice the 3D field to be recorded. If
-                None, then the complete field will be recorded. Use 0 for X axis, 1
-                for Y axis and 2 for Z axis.
-            slice_position: the position (in meters) along the slice axis at
-                which the slice of the 3D field should be made.
-
-        Raises:
-            ValueError if axis is not 0, 1, 2.
-            ValueError if `slice_position` falls outside the current range of
-                `slice_axis`.
-            ValueError if  `slice_axis` is None or `slice_position` is None.
-        """
-        if slice_axis is None or slice_position is None:
-            raise ValueError(
-                "Both `slice_axis` and `slice_position` must be passed together "
-                "to correctly define how to slice the field. "
-            )
-        if slice_axis not in (0, 1, 2):
-            raise ValueError(
-                "Unexpected value received for `slice_axis`. ",
-                "Expected axis are 0 (X), 1 (Y) and/or 2 (Z).",
-            )
-
-        origin = np.array(self.scenario.origin, dtype=float)
-        extent = self.scenario.extent
-
-        current_range = (origin[slice_axis], origin[slice_axis] + extent[slice_axis])
-        if (slice_position < current_range[0]) or (slice_position > current_range[1]):
-            raise ValueError(
-                "`slice_position` is out of range for `slice_axis`. ",
-                f"Received value {slice_position} and "
-                f"current range is {current_range}.",
-            )
-
     def get_steady_state_result_2d(
         self,
         slice_axis: Optional[SliceAxis] = None,

--- a/src/neurotechdevkit/results/_results.py
+++ b/src/neurotechdevkit/results/_results.py
@@ -282,7 +282,7 @@ class SteadyStateResult2D(SteadyStateResult):
                 upsample_factor=self.scenario.material_outline_upsample_factor,
             )
         if show_target:
-            if not hasattr(self.scenario, "target"):
+            if not hasattr(self.scenario, "_target"):
                 print(
                     "WARNING: No target was specified in the scenario. "
                     "Not showing target layer."
@@ -565,7 +565,6 @@ class SteadyStateResult3D(SteadyStateResult):
             wavefield=self.wavefield,
             traces=self.traces,
         )
-
         result.steady_state = steady_state
 
         return result

--- a/src/neurotechdevkit/results/_results.py
+++ b/src/neurotechdevkit/results/_results.py
@@ -203,6 +203,9 @@ class SteadyStateResult(Result):
             A dictionary with the objects to be saved to disk.
         """
         material_outline = self.scenario.material_outline_upsample_factor
+        sources = None
+        if hasattr(self.scenario, "sources"):
+            sources = self.scenario.sources
         save_data = {
             "result_type": self.__class__,
             "material_masks": self.scenario.material_masks,
@@ -212,7 +215,7 @@ class SteadyStateResult(Result):
             "is_3d": isinstance(self.scenario, scenarios.Scenario3D),
             "origin": self.scenario.origin,
             "grid": self.scenario.grid,
-            "sources": self.scenario.sources,
+            "sources": sources,
             "problem": self.scenario.problem,
             "center_frequency": self.center_frequency,
             "effective_dt": self.effective_dt,
@@ -282,14 +285,14 @@ class SteadyStateResult2D(SteadyStateResult):
                 upsample_factor=self.scenario.material_outline_upsample_factor,
             )
         if show_target:
-            try:
-                rendering.draw_target(
-                    ax, self.scenario.target_center, self.scenario.target_radius
-                )
-            except AssertionError:
+            if self.scenario.target is None:
                 print(
                     "WARNING: No target was specified in the scenario. "
                     "Not showing target layer."
+                )
+            else:
+                rendering.draw_target(
+                    ax, self.scenario.target_center, self.scenario.target_radius
                 )
         if show_sources:
             if not hasattr(self.scenario, "sources"):

--- a/src/neurotechdevkit/results/_results.py
+++ b/src/neurotechdevkit/results/_results.py
@@ -443,20 +443,17 @@ class SteadyStateResult3D(SteadyStateResult):
             ValueError if axis is not 0, 1, 2.
             ValueError if `slice_position` falls outside the current range of
                 `slice_axis`.
-            ValueError if  `slice_axis` is None but `slice_position` is not None and
-                vice versa.
+            ValueError if  `slice_axis` is None or `slice_position` is None.
         """
+        if slice_axis is None or slice_position is None:
+            raise ValueError(
+                "Both `slice_axis` and `slice_position` must be passed together "
+                "to correctly define how to slice the field. "
+            )
         if slice_axis not in (0, 1, 2):
             raise ValueError(
                 "Unexpected value received for `slice_axis`. ",
                 "Expected axis are 0 (X), 1 (Y) and/or 2 (Z).",
-            )
-        if (slice_axis is None and slice_position is not None) or (
-            slice_axis is not None and slice_position is None
-        ):
-            raise ValueError(
-                "Both `slice_axis` and `slice_position` must be passed together "
-                "to correctly define how to slice the field. "
             )
 
         origin = np.array(self.scenario.origin, dtype=float)
@@ -489,13 +486,13 @@ class SteadyStateResult3D(SteadyStateResult):
             are not being accounted for and will not be preserved in the 2D result.
 
         Args:
-            slice_axis (Optional[SliceAxis], optional): The axis along which to slice
-                the 3D field to be recorded. If None, then the complete field will be
-                recorded. Use 0 for X axis, 1 for Y axis and 2 for Z axis. Defaults to
-                None.
-            slice_position (Optional[float], optional): The position (in meters) along
-                the slice axis at which the slice of the 3D field should be made.
-                Defaults to None.
+            slice_axis: The axis along which to slice the 3D field to be recorded. If
+                None, then the complete field will be recorded. Use 0 for X axis, 1 for
+                Y axis and 2 for Z axis. Defaults to None.
+            slice_position: The position (in meters) along the slice axis at which the
+                slice of the 3D field should be made. Position must be within the slice
+                axis range. Eg. for a slice with origin -0.035 and extent 0.07, the
+                valid range is [-0.035, 0.035]. Defaults to None.
 
         Returns:
             A SteadyStateResult2D object containing the 2D slice of the 3D steady-state
@@ -595,8 +592,8 @@ class SteadyStateResult3D(SteadyStateResult):
             shot=self.shot,
             wavefield=wavefield,
             traces=self.traces,
+            steady_state=steady_state,
         )
-        result.steady_state = steady_state
 
         return result
 

--- a/src/neurotechdevkit/results/_results.py
+++ b/src/neurotechdevkit/results/_results.py
@@ -521,17 +521,22 @@ class SteadyStateResult3D(SteadyStateResult):
             source_args = {
                 "position": drop_element(source.position, slice_axis),
                 "direction": drop_element(source.unit_direction, slice_axis),
-                "aperture": source.aperture,
-                "focal_length": source.focal_length,
                 "num_points": source.num_points,
-                "delay": source.delay,
             }
-            if type(source) == sources.PhasedArraySource3D:
+            if isinstance(source, sources.PhasedArraySource3D):
+                if source.element_delays is None:
+                    source_args["tilt_angle"] = source.tilt_angle
+                    source_args["focal_length"] = source.focal_length
+                    source_args["delay"] = source.delay
                 source_args["num_elements"] = source.num_elements
                 source_args["pitch"] = source.pitch
                 source_args["element_width"] = source.element_width
-                source_args["tilt_angle"] = source.tilt_angle
                 source_args["element_delays"] = source.element_delays
+            else:
+                source_args["aperture"] = source.aperture
+                source_args["delay"] = source.delay
+                if not isinstance(source, sources.UnfocusedSource):
+                    source_args["focal_length"] = source.focal_length
             sources_2d.append(source_type[type(source)](**source_args))
 
         target = Target(

--- a/src/neurotechdevkit/results/_results.py
+++ b/src/neurotechdevkit/results/_results.py
@@ -282,14 +282,14 @@ class SteadyStateResult2D(SteadyStateResult):
                 upsample_factor=self.scenario.material_outline_upsample_factor,
             )
         if show_target:
-            if not hasattr(self.scenario, "_target"):
+            try:
+                rendering.draw_target(
+                    ax, self.scenario.target_center, self.scenario.target_radius
+                )
+            except AssertionError:
                 print(
                     "WARNING: No target was specified in the scenario. "
                     "Not showing target layer."
-                )
-            else:
-                rendering.draw_target(
-                    ax, self.scenario.target_center, self.scenario.target_radius
                 )
         if show_sources:
             if not hasattr(self.scenario, "sources"):
@@ -523,12 +523,11 @@ class SteadyStateResult3D(SteadyStateResult):
         wavefield = self.wavefield
         if wavefield is not None:
             wavefield = slice_field(
-                self.steady_state, self.scenario, slice_axis, slice_position
+                self.wavefield, self.scenario, slice_axis, slice_position
             )
 
-        assert self.steady_state is not None
         steady_state = slice_field(
-            self.steady_state, self.scenario, slice_axis, slice_position
+            self.get_steady_state(), self.scenario, slice_axis, slice_position
         )
 
         grid = Grid.make_grid(

--- a/src/neurotechdevkit/scenarios/__init__.py
+++ b/src/neurotechdevkit/scenarios/__init__.py
@@ -1,7 +1,8 @@
 """Scenarios module."""
 from .. import materials
 from . import built_in
-from ._base import Scenario, Scenario2D, Scenario3D, Target
+from ._base import Scenario, Scenario2D, Scenario3D
+from ._utils import Target
 
 __all__ = [
     "materials",

--- a/src/neurotechdevkit/scenarios/_base.py
+++ b/src/neurotechdevkit/scenarios/_base.py
@@ -195,11 +195,15 @@ class Scenario(abc.ABC):
     @property
     def target_center(self) -> npt.NDArray[np.float_]:
         """The coordinates of the center of the target region (in meters)."""
+        if self.target is None:
+            return None
         return np.array(self.target.center, dtype=float)
 
     @property
     def target_radius(self) -> float:
         """The radius of the target region (in meters)."""
+        if self.target is None:
+            return None
         return self.target.radius
 
     @property
@@ -251,7 +255,8 @@ class Scenario(abc.ABC):
     @property
     def target(self) -> Target:
         """The target in the scenario."""
-        assert hasattr(self, "_target")
+        if not hasattr(self, "_target"):
+            return None
         return self._target
 
     @target.setter
@@ -811,6 +816,8 @@ class Scenario2D(Scenario):
 
     def get_target_mask(self) -> npt.NDArray[np.bool_]:
         """Return the mask for the target region."""
+        if self.target is None:
+            return None
         target_mask = create_grid_circular_mask(
             grid=self.problem.grid,
             origin=np.array(self.origin, dtype=float),
@@ -897,12 +904,23 @@ class Scenario2D(Scenario):
                 upsample_factor=self.material_outline_upsample_factor,
             )
         if show_target:
-            rendering.draw_target(ax, self.target_center, self.target_radius)
+            if self.target is None:
+                print(
+                    "WARNING: No target was specified in the scenario. "
+                    "Not showing target layer."
+                )
+            else:
+                rendering.draw_target(ax, self.target_center, self.target_radius)
         if show_sources:
-            assert self.sources
-            for source in self.sources:
-                drawing_params = rendering.SourceDrawingParams.from_source(source)
-                rendering.draw_source(ax, drawing_params)
+            if not hasattr(self, "sources"):
+                print(
+                    "WARNING: No sources were specified in the scenario. "
+                    "Not showing source layer."
+                )
+            else:
+                for source in self.sources:
+                    drawing_params = rendering.SourceDrawingParams.from_source(source)
+                    rendering.draw_source(ax, drawing_params)
 
         rendering.configure_layout_plot(
             fig=fig,

--- a/src/neurotechdevkit/scenarios/_base.py
+++ b/src/neurotechdevkit/scenarios/_base.py
@@ -674,20 +674,17 @@ class Scenario(abc.ABC):
             ValueError if axis is not 0, 1, 2.
             ValueError if `slice_position` falls outside the current range of
                 `slice_axis`.
-            ValueError if  `slice_axis` is None but `slice_position` is not None and
-                vice versa.
+            ValueError if  `slice_axis` is None or `slice_position` is None.
         """
+        if slice_axis is None or slice_position is None:
+            raise ValueError(
+                "Both `slice_axis` and `slice_position` must be passed together "
+                "to correctly define how to slice the field. "
+            )
         if slice_axis not in (0, 1, 2):
             raise ValueError(
                 "Unexpected value received for `slice_axis`. ",
                 "Expected axis are 0 (X), 1 (Y) and/or 2 (Z).",
-            )
-        if (slice_axis is None and slice_position is not None) or (
-            slice_axis is not None and slice_position is None
-        ):
-            raise ValueError(
-                "Both `slice_axis` and `slice_position` must be passed together "
-                "to correctly define how to slice the field. "
             )
 
         origin = np.array(self.origin, dtype=float)

--- a/src/neurotechdevkit/scenarios/_base.py
+++ b/src/neurotechdevkit/scenarios/_base.py
@@ -4,7 +4,6 @@ import abc
 import asyncio
 import os
 from dataclasses import dataclass
-from enum import IntEnum
 from types import SimpleNamespace
 from typing import Mapping, Optional, Union
 
@@ -33,19 +32,12 @@ from ._utils import (
     create_grid_circular_mask,
     create_grid_spherical_mask,
     drop_element,
+    SliceAxis,
     slice_field,
     wavelet_helper,
 )
 
 nest_asyncio.apply()
-
-
-class SliceAxis(IntEnum):
-    """Axis along which to slice the 3D field to be recorded."""
-
-    X = 0
-    Y = 1
-    Z = 2
 
 
 @dataclass

--- a/src/neurotechdevkit/scenarios/_utils.py
+++ b/src/neurotechdevkit/scenarios/_utils.py
@@ -4,7 +4,14 @@ import numpy as np
 import numpy.typing as npt
 import stride
 from stride.utils import wavelets
+from enum import IntEnum
 
+class SliceAxis(IntEnum):
+    """Axis along which to slice the 3D field to be recorded."""
+
+    X = 0
+    Y = 1
+    Z = 2
 
 def choose_wavelet_for_mode(simulation_mode: str) -> str:
     """Return the appropriate wavelet name for a given simulation mode.

--- a/src/neurotechdevkit/scenarios/_utils.py
+++ b/src/neurotechdevkit/scenarios/_utils.py
@@ -1,10 +1,30 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import IntEnum
+
 import numpy as np
 import numpy.typing as npt
 import stride
 from stride.utils import wavelets
-from enum import IntEnum
+
+
+@dataclass
+class Target:
+    """A class for containing metadata for a target.
+
+    Attributes:
+        target_id: the string id of the target.
+        center: the location of the center of the target (in meters).
+        radius: the radius of the target (in meters).
+        description: a text describing the target.
+    """
+
+    target_id: str
+    center: list[float]
+    radius: float
+    description: str
+
 
 class SliceAxis(IntEnum):
     """Axis along which to slice the 3D field to be recorded."""
@@ -12,6 +32,7 @@ class SliceAxis(IntEnum):
     X = 0
     Y = 1
     Z = 2
+
 
 def choose_wavelet_for_mode(simulation_mode: str) -> str:
     """Return the appropriate wavelet name for a given simulation mode.

--- a/src/neurotechdevkit/scenarios/built_in/_scenario_0.py
+++ b/src/neurotechdevkit/scenarios/built_in/_scenario_0.py
@@ -6,8 +6,8 @@ import numpy.typing as npt
 from ...grid import Grid
 from ...materials import Material
 from ...sources import FocusedSource2D
-from .._base import Scenario2D, Target
-from .._utils import create_grid_circular_mask, create_grid_elliptical_mask
+from .._base import Scenario2D
+from .._utils import Target, create_grid_circular_mask, create_grid_elliptical_mask
 
 
 class Scenario0(Scenario2D):

--- a/src/neurotechdevkit/scenarios/built_in/_scenario_1.py
+++ b/src/neurotechdevkit/scenarios/built_in/_scenario_1.py
@@ -8,8 +8,8 @@ import numpy.typing as npt
 from ... import rendering, sources
 from ...grid import Grid
 from ...materials import Material
-from .._base import Scenario, Scenario2D, Scenario3D, Target
-from .._utils import SliceAxis
+from .._base import Scenario, Scenario2D, Scenario3D
+from .._utils import SliceAxis, Target
 
 
 class Scenario1(Scenario):

--- a/src/neurotechdevkit/scenarios/built_in/_scenario_1.py
+++ b/src/neurotechdevkit/scenarios/built_in/_scenario_1.py
@@ -8,7 +8,8 @@ import numpy.typing as npt
 from ... import rendering, sources
 from ...grid import Grid
 from ...materials import Material
-from .._base import Scenario, Scenario2D, Scenario3D, SliceAxis, Target
+from .._base import Scenario, Scenario2D, Scenario3D, Target
+from .._utils import SliceAxis
 
 
 class Scenario1(Scenario):

--- a/src/neurotechdevkit/scenarios/built_in/_scenario_2.py
+++ b/src/neurotechdevkit/scenarios/built_in/_scenario_2.py
@@ -11,7 +11,8 @@ import scipy.ndimage
 from ... import rendering, sources
 from ...grid import Grid
 from ...materials import Material
-from .._base import Scenario, Scenario2D, Scenario3D, SliceAxis, Target
+from .._base import Scenario, Scenario2D, Scenario3D, Target
+from .._utils import SliceAxis
 
 
 class Scenario2(Scenario):

--- a/src/neurotechdevkit/scenarios/built_in/_scenario_2.py
+++ b/src/neurotechdevkit/scenarios/built_in/_scenario_2.py
@@ -11,8 +11,8 @@ import scipy.ndimage
 from ... import rendering, sources
 from ...grid import Grid
 from ...materials import Material
-from .._base import Scenario, Scenario2D, Scenario3D, Target
-from .._utils import SliceAxis
+from .._base import Scenario, Scenario2D, Scenario3D
+from .._utils import SliceAxis, Target
 
 
 class Scenario2(Scenario):

--- a/tests/neurotechdevkit/scenarios/test_results.py
+++ b/tests/neurotechdevkit/scenarios/test_results.py
@@ -491,12 +491,18 @@ def test_creation_of_pulsed_3d_results_sliced(result_args, recorded_slice):
     assert isinstance(result, PulsedResult3D)
 
 
-@pytest.mark.parametrize("slice_args", [(3, 0.0), (None, 0.0), (1, None), (1, 0.5)])
-def test_validate_slice_args(fake_ss_result_3d, a_test_scenario_3d, slice_args):
+@pytest.mark.parametrize(
+    "slice_axis, slice_position", [(3, 0.0), (None, 0.0), (1, None), (1, 0.5)]
+)
+def test_validate_slice_args(
+    fake_ss_result_3d, a_test_scenario_3d, slice_axis, slice_position
+):
     """Validates that raises error if trying to perform invalid slice"""
     fake_ss_result_3d.scenario = a_test_scenario_3d
     with pytest.raises(ValueError):
-        fake_ss_result_3d._validate_slice_args(*slice_args)
+        fake_ss_result_3d._validate_slice_args(
+            slice_axis=slice_axis, slice_position=slice_position
+        )
 
 
 def test_get_steady_state_result_2d(

--- a/tests/neurotechdevkit/scenarios/test_results.py
+++ b/tests/neurotechdevkit/scenarios/test_results.py
@@ -491,20 +491,6 @@ def test_creation_of_pulsed_3d_results_sliced(result_args, recorded_slice):
     assert isinstance(result, PulsedResult3D)
 
 
-@pytest.mark.parametrize(
-    "slice_axis, slice_position", [(3, 0.0), (None, 0.0), (1, None), (1, 0.5)]
-)
-def test_validate_slice_args(
-    fake_ss_result_3d, a_test_scenario_3d, slice_axis, slice_position
-):
-    """Validates that raises error if trying to perform invalid slice"""
-    fake_ss_result_3d.scenario = a_test_scenario_3d
-    with pytest.raises(ValueError):
-        fake_ss_result_3d._validate_slice_args(
-            slice_axis=slice_axis, slice_position=slice_position
-        )
-
-
 def test_get_steady_state_result_2d(
     fake_ss_result_3d, ss_data_3d, a_test_scenario_3d, a_test_scenario_2d
 ):


### PR DESCRIPTION
#### Introduction

https://github.com/agencyenterprise/neurotechdevkit/issues/134
This PR adds the `get_steady_state_result_2d` method to the `SteadyStateResult3D` class to be able to convert the `SteadyStateResult3D` output of a 3-D simulation to a `SteadyStateResult2D` that just encapsulates the slice of interest.

#### Changes

The `get_steady_state_result_2d` method with optional arguments of `slice_axis` and `slice_position` (the `slice_axis` and `slice_position` property of the 3D result is used when none is given) is added to the `SteadyStateResult3D` class in `_results.py`. The method `_validate_slice_args` is also added to `SteadyStateResult3D` to check the slice being made. The `SteadyStateResult2D` object returned by the `get_steady_state_result_2d` method has the target and sources removed (should be changed to the correctly sliced target and sources in https://github.com/agencyenterprise/neurotechdevkit/issues/148); warnings for missing target/sources are added to the rendering and metrics of `SteadyStateResult2D`. Moved definition of SliceAxis enum from `_base.py` to `_utils.py`, so the `get_steady_state_result_2d` method can be typed.

#### Behavior

The new behavior is the generation of a 2D steady-state result object from a 3D steady-state result object by the `get_steady_state_result_2d` method of the `SteadyStateResult3D` class. This can be tested by making a 3D steady-state result and calling the method to generate a 2D slice of that result.
