### PR TITLE
Include gallery images in CircleCI-generated docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: Build HTML
           command: |
-            make docs
+            OFFLINE=true make docs
 
       - save_cache:
           key: docs-{{ epoch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,16 +39,6 @@ jobs:
           command: |
             OFFLINE=true make docs
 
-      - run:
-          name: Move HTML files into their own directories
-          command: |
-            for file in $(find . -name "*.html"); do
-              dir=$(dirname "$file")
-              base=$(basename "$file" .html)
-              mkdir -p "$dir/$base"
-              mv "$file" "$dir/$base/index.html"
-            done
-
       - save_cache:
           key: docs-{{ epoch }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,16 @@ jobs:
           command: |
             OFFLINE=true make docs
 
+      - run:
+          name: Move HTML files into their own directories
+          command: |
+            for file in $(find . -name "*.html"); do
+              dir=$(dirname "$file")
+              base=$(basename "$file" .html)
+              mkdir -p "$dir/$base"
+              mv "$file" "$dir/$base/index.html"
+            done
+
       - save_cache:
           key: docs-{{ epoch }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: Build HTML
           command: |
-            OFFLINE=true make docs
+            make docs
 
       - save_cache:
           key: docs-{{ epoch }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,11 @@ plugins:
 
   - search
 
+  # The following plugin allows us to navigate through the documentation
+  # from the built docs, as mkdocs will not generate full path URLs by default.
+  - offline:
+      enabled: !ENV [OFFLINE, false]
+
   - mkdocstrings:
       default_handler: python
       handlers:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,10 +77,9 @@ plugins:
 
   - search
 
-  # The following plugin allows us to navigate through the documentation
-  # from the built docs, as mkdocs will not generate full path URLs by default.
-  - offline:
+  - offline-links:
       enabled: !ENV [OFFLINE, false]
+
 
   - mkdocstrings:
       default_handler: python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,11 +77,6 @@ plugins:
 
   - search
 
-  # The following plugin allows us to navigate through the documentation
-  # from the built docs, as mkdocs will not generate full path URLs by default.
-  - offline:
-      enabled: !ENV [OFFLINE, false]
-
   - mkdocstrings:
       default_handler: python
       handlers:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2186,6 +2186,24 @@ files = [
 ]
 
 [[package]]
+name = "mkdocs-offline-links-plugin"
+version = "0.1.0"
+description = ""
+optional = false
+python-versions = ">=3.9"
+files = []
+develop = false
+
+[package.dependencies]
+mkdocs = ">=1.5.0"
+
+[package.source]
+type = "git"
+url = "https://github.com/charlesincharge/mkdocs-offline-links-plugin.git"
+reference = "HEAD"
+resolved_reference = "c807fb0ffd79d3776ac20d38bacefff28fcc70aa"
+
+[[package]]
 name = "mkdocstrings"
 version = "0.21.2"
 description = "Automatic documentation from sources, for MkDocs."
@@ -4565,4 +4583,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "8215fd779d7a2cf4d184f76f125657518d3011f6ed3204f1488c83b2cf791dd0"
+content-hash = "7a1ccbc1d0705978be50d966641bd95ca387d7b119dbd853951ed2c5bd4fb527"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2188,7 +2188,7 @@ files = [
 [[package]]
 name = "mkdocs-offline-links-plugin"
 version = "0.1.0"
-description = ""
+description = "A MkDocs plugin to make links to other pages in the site work offline."
 optional = false
 python-versions = ">=3.9"
 files = []
@@ -2199,9 +2199,9 @@ mkdocs = ">=1.5.0"
 
 [package.source]
 type = "git"
-url = "https://github.com/charlesincharge/mkdocs-offline-links-plugin.git"
+url = "https://github.com/agencyenterprise/mkdocs-offline-links-plugin.git"
 reference = "HEAD"
-resolved_reference = "c807fb0ffd79d3776ac20d38bacefff28fcc70aa"
+resolved_reference = "ff648260cc73dabb037b43d8b21ba912ae33de20"
 
 [[package]]
 name = "mkdocstrings"
@@ -4583,4 +4583,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "7a1ccbc1d0705978be50d966641bd95ca387d7b119dbd853951ed2c5bd4fb527"
+content-hash = "6f41f3924d8554a00dbade860231b5e372fe7ef2265771bafca4f3f75bfe9ece"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ pytest-cov = "^4.0.0"
 pytest-asyncio = "^0.20.2"
 mkdocs-material = "^9.1.6"
 mkdocs-gallery = "^0.7.6"
+mkdocs-offline-links-plugin = { git = "https://github.com/charlesincharge/mkdocs-offline-links-plugin.git" }
 mkdocstrings = {extras = ["python"], version = "^0.21.2"}
 codespell = "^2.2.4"
 pydocstyle = "^6.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ pytest-cov = "^4.0.0"
 pytest-asyncio = "^0.20.2"
 mkdocs-material = "^9.1.6"
 mkdocs-gallery = "^0.7.6"
-mkdocs-offline-links-plugin = { git = "https://github.com/charlesincharge/mkdocs-offline-links-plugin.git" }
+mkdocs-offline-links-plugin = { git = "https://github.com/agencyenterprise/mkdocs-offline-links-plugin.git" }
 mkdocstrings = {extras = ["python"], version = "^0.21.2"}
 codespell = "^2.2.4"
 pydocstyle = "^6.3.0"


### PR DESCRIPTION
https://github.com/agencyenterprise/neurotechdevkit/issues/141

#### Introduction

We use CircleCI to generate docs webpages for every pull request. This is particularly helpful to view for pull requests that add or edit `docs/examples `scripts.

Unfortunately, our current PR/CircleCI docs do not include figures, showing them only as broken links, e.g.:
![image](https://github.com/agencyenterprise/neurotechdevkit/assets/3221512/280939e5-7f03-4d62-8ff0-7e815f73509e)

The root cause appears to be an issue with the paths, as a local build (which shows images correctly) puts, e.g. the `plot_time_reverse` page at 
`http://127.0.0.1:8000/neurotechdevkit/generated/gallery/plot_time_reverse/` but then on CI, it shows up not in its own folder but as:
`https://output.circle-artifacts.com/output/job/a9676679-2d73-455d-a473-c666c02fa461/artifacts/0/html/generated/gallery/plot_time_reverse.html`

This appears to be the result of a slight difference in [`build_docs_pr`](https://github.com/agencyenterprise/neurotechdevkit/blob/aea64a0/.circleci/config.yml#L40) vs local doc builds or [`build_docs_no_cache`](https://github.com/agencyenterprise/neurotechdevkit/blob/aea64a0/.circleci/config.yml#L82) for the main website.
Specifically, the PR build_docs use 
 https://squidfunk.github.io/mkdocs-material/setup/building-for-offline-usage/ , which changes whether pages are directory URLs or `.html` files:
* https://github.com/squidfunk/mkdocs-material/blob/950d1e41fb540a29fd785d00e73a1c5ae5e0a2f1/docs/plugins/offline.md?plain=1#L37-L39
* https://www.mkdocs.org/user-guide/configuration/#use_directory_urls
It seems there is some slight incompatibility between the `offline` and `mkdocs-gallery` plugins in terms of where files/images are expected.

#### Changes
* Swap out `mkdocs`'s [offline plugin](https://squidfunk.github.io/mkdocs-material/setup/building-for-offline-usage/) for a [custom plugin](https://github.com/agencyenterprise/mkdocs-offline-links-plugin) on CircleCI builds
    * Note: the `offline` plugin is already disabled on local builds and when building the production website.
    * The custom plugin simply sets each page's `url` to its `dest_uri`. Some examples of original `url` and `dest_uri` values:
        * `File(src_uri='index.md', dest_uri='index.html', name='index', url='./')`
        * `File(src_uri='contributing.md', dest_uri='contributing/index.html', name='contributing', url='contributing/')`

##### Design decisions

* Explicitly change the page URLs in `offlink-links` mode
    * It unfortunately wasn't as simple as disabling the `offline` mode, because `CircleCI` simply uploads the web-page files to an S3 bucket (rather than serving a `mkdocs` website), so `CircleCI` won't take care of redirecting `url='contributing/'` to `url='contributing/index.html'`

* Decided it is more important to:
    * be able to view the gallery-generated images, than to:
    * be able to site-search the docs **offline**. We can still site-search the docs online and on CircleCI

#### Behavior

View figure images in the generated CI docs, e.g. (from https://output.circle-artifacts.com/output/job/8e437392-4580-4896-9d68-8d87b5fbcb4d/artifacts/0/html/generated/gallery/plot_customized_center_frequency/index.html)
<img width="1061" alt="image" src="https://github.com/agencyenterprise/neurotechdevkit/assets/3221512/50005f8e-2156-4fd0-a492-76d01ddc7652">

##### Not solved
https://output.circle-artifacts.com/output/job/8e437392-4580-4896-9d68-8d87b5fbcb4d/artifacts/0/html/generated/gallery/index.html still links the examples using the directory naming, e.g. https://output.circle-artifacts.com/output/job/8e437392-4580-4896-9d68-8d87b5fbcb4d/artifacts/0/html/generated/gallery/plot_customized_center_frequency . We need to add `/index.html` to these links to make them work.