### PR TITLE
Document spellcheck issue on Mac M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,13 @@ lint:
 	poetry run pyright
 
 spellcheck:
+	# If you are using an Apple Silicon Mac, there is currently an issue with
+	# pyenchant (https://github.com/pyenchant/pyenchant/issues/265) that prevents
+	# this spellcheck command from finding the enchant library (and en_US). 
+	# Until pyenchant is fixed, one workaround is to run:
+	#    `export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib`
+	# in the terminal environment before you run `make spellcheck`
+	# See: https://github.com/pyenchant/pyenchant/issues/265#issuecomment-998965819
 	poetry run pylint --disable all --enable spelling --spelling-dict en_US --spelling-private-dict-file=whitelist.txt src
 
 lint-check:


### PR DESCRIPTION
#### Introduction

`make spellcheck` relies on `pyenchant`, which fails on Apple Silicon Mac (e.g., M1) to find the `C enchant` library: https://github.com/pyenchant/pyenchant/issues/265

This shows up as a `en_US`-not-found error on my M1 Mac.

#### Changes

When running `make spellcheck`, it now also prints this recommended workaround:
```shell
❯ make spellcheck
# If you are using an Apple Silicon Mac, there is currently an issue with
# pyenchant (https://github.com/pyenchant/pyenchant/issues/265) that prevents
# this spellcheck command from finding the enchant library (and en_US).
# Until pyenchant is fixed, one workaround is to run:
#    `export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib`
# in the terminal environment before you run `make spellcheck`
# See: https://github.com/pyenchant/pyenchant/issues/265#issuecomment-998965819
poetry run pylint --disable all --enable spelling --spelling-dict en_US --spelling-private-dict-file=whitelist.txt src
```

Given that the number of users using Apple Silicon Mac will increase (as Apple phases out x86) and that only NDK developers (not users) will run `make spellcheck`, I think it's reasonable to surface this directly in the command, instead of making the `Makefile` comment silent.

#### Behavior

After adding `export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib` to my `.zshenv` as mentioned, I can run `make spellcheck` completely.