### PR TITLE
Pin stride version in all the places we specify pip install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
           name: Install stride
           command: |
-            poetry run pip install git+https://github.com/trustimaging/stride
+            poetry run pip install git+https://github.com/trustimaging/stride@2520c59
 
       - restore_cache:
           name: Restore docs cache
@@ -73,7 +73,7 @@ jobs:
       - run:
           name: Install stride
           command: |
-            poetry run pip install git+https://github.com/trustimaging/stride
+            poetry run pip install git+https://github.com/trustimaging/stride@2520c59
 
       - run:
           name: Build docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: Install stride
-        run: poetry run pip install git+https://github.com/trustimaging/stride
+        run: poetry run pip install git+https://github.com/trustimaging/stride@2520c59
 
       - name: Install napari
         run: poetry run pip install "napari[all,pyqt6_experimental]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: Install stride
-        run: poetry run pip install git+https://github.com/trustimaging/stride
+        run: poetry run pip install git+https://github.com/trustimaging/stride@2520c59
 
       - name: Install neurotechdevkit
         run: poetry install --only-root

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN python3 -m venv ./venv && \
 
 ENV POETRY_VIRTUALENVS_CREATE=false
 RUN ./venv/bin/poetry install && \
-    ./venv/bin/pip install git+https://github.com/trustimaging/stride
+    ./venv/bin/pip install git+https://github.com/trustimaging/stride@2520c59
 
 FROM python:3.10.0-slim
 

--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -16,7 +16,7 @@ RUN python3 -m venv ./venv && \
 
 ENV POETRY_VIRTUALENVS_CREATE=false
 RUN ./venv/bin/poetry install && \
-    ./venv/bin/pip install git+https://github.com/trustimaging/stride
+    ./venv/bin/pip install git+https://github.com/trustimaging/stride@2520c59
 
 
 FROM nvcr.io/nvidia/nvhpc:23.5-devel-cuda_multi-ubuntu22.04 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -60,7 +60,7 @@ This will resolve and install the dependencies from `poetry.lock` and will insta
 Install stride with:
 
 ```bash
-$ poetry run pip install git+https://github.com/trustimaging/stride
+$ poetry run pip install git+https://github.com/trustimaging/stride@2520c59
 ```
 
 Follow the steps described in [Setting up a compiler](installation.md#setting-up-a-compiler).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,7 +33,7 @@ pip install neurotechdevkit
 You also have to install stride, it can be done running:
 
 ```bash
-pip install git+https://github.com/trustimaging/stride
+pip install git+https://github.com/trustimaging/stride@2520c59
 ```
 
 ## Setting up a compiler

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,7 +38,7 @@ pip install git+https://github.com/trustimaging/stride@2520c59
 
 ## Setting up a compiler
 
-NDK uses [devito](https://www.devitoproject.org/devito/) to perform the heavy computational operations. Devito generates, compiles and runs C code to achieve better performance.
+NDK uses [devito](https://www.devitoproject.org/) to perform the heavy computational operations. Devito generates, compiles and runs C code to achieve better performance.
 The compiler used by Devito has to be selected, and paths for the linker might also be added as environment variables.
 
 As a last step **before running NDK**, follow the instructions below depending on your OS.


### PR DESCRIPTION
https://github.com/agencyenterprise/neurotechdevkit/issues/142

#### Introduction

NDK uses the `stride` simulation software, and we instruct users to `pip install` from Github, picking up the latest development version. `stride` currently has a bug or 2 causing some NDK tests to fail (and potentially breaking for any new NDK users).

#### Changes

* Pin `stride` to a known-good commit SHA. Categorized as "known-good" simply as having passed the automated tests: https://github.com/agencyenterprise/neurotechdevkit/pull/152

In the future:
* It would be useful to find a way to pull this into `poetry` so it is one less thing to track.
* We may need to update `stride` to do releases for this to work.

#### Behavior
* Automated tests should pass
* All `pip install stride` commands should have respective commit hashes


FYI @conditg 