### PR TITLE
Fix plot_time_reverse.py time-reverse simulation

### DIFF
--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -111,7 +111,7 @@ pressure_at_elements = result.wavefield[element_indices[:, 0], element_indices[:
 element_reverse_delays = np.argmax(pressure_at_elements, axis=1) * result.effective_dt
 plt.plot(element_reverse_delays, marker="o")
 plt.xlabel("element index")
-plt.ylabel("delay [s]")
+_ = plt.ylabel("delay [s]")
 
 
 # %%

--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -177,7 +177,7 @@ steady_state_result.render_steady_state_amplitudes()
 # target.
 max_pressure_idx = steady_state_result.metrics["focal_position"]["value"]
 assert isinstance(max_pressure_idx, tuple)
-assert all(isinstance(idx, int) for idx in max_pressure_idx)
+assert all(np.issubdtype(type(idx), np.integer) for idx in max_pressure_idx)
 grid = steady_state_result.traces.grid.space.grid
 focal_point = np.array(
     [

--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -73,7 +73,7 @@ reversed_scenario = ndk.scenarios.built_in.Scenario2_2D()
 point_source = ndk.sources.PointSource2D(
     position=true_scenario.target.center,
 )
-reversed_scenario.sources.append(point_source)
+reversed_scenario.sources = [point_source]
 
 reversed_scenario.make_grid()
 reversed_scenario.compile_problem()

--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -176,6 +176,8 @@ steady_state_result.render_steady_state_amplitudes()
 # We can also calculate how far the "time reverse" estimate is from the true
 # target.
 max_pressure_idx = steady_state_result.metrics["focal_position"]["value"]
+assert isinstance(max_pressure_idx, tuple)
+assert all(isinstance(idx, int) for idx in max_pressure_idx)
 grid = steady_state_result.traces.grid.space.grid
 focal_point = np.array(
     [

--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -175,10 +175,7 @@ steady_state_result.render_steady_state_amplitudes()
 # %%
 # We can also calculate how far the "time reverse" estimate is from the true
 # target.
-max_pressure_flat_idx = np.nanargmax(steady_state_pressure)
-max_pressure_idx = np.unravel_index(max_pressure_flat_idx, steady_state_pressure.shape)
-max_pressure_idx
-
+max_pressure_idx = steady_state_result.metrics["focal_position"]["value"]
 grid = steady_state_result.traces.grid.space.grid
 focal_point = np.array(
     [

--- a/docs/examples/plot_time_reverse.py
+++ b/docs/examples/plot_time_reverse.py
@@ -91,6 +91,7 @@ result.render_pulsed_simulation_animation()
 # the true array elements. Here, we coarsely approximate these delays by
 # finding the pressure argmax at each element's nearest-neighbor coordinates.
 
+
 # Map array elements onto the nearest pixels in our simulation
 def map_coordinates_to_indices(coordinates, origin, dx):
     indices = np.round((coordinates - origin) / dx).astype(int)

--- a/src/neurotechdevkit/rendering/colormaps.py
+++ b/src/neurotechdevkit/rendering/colormaps.py
@@ -1387,14 +1387,13 @@ _parula_data = [
 from matplotlib.colors import ListedColormap  # noqa: E402
 
 cmaps = {}
-for (name, data) in (
+for name, data in (
     ("magma", _magma_data),
     ("inferno", _inferno_data),
     ("plasma", _plasma_data),
     ("viridis", _viridis_data),
     ("parula", _parula_data),
 ):
-
     cmaps[name] = ListedColormap(data, name=name)
 
 magma = cmaps["magma"]

--- a/src/neurotechdevkit/results/_metrics.py
+++ b/src/neurotechdevkit/results/_metrics.py
@@ -33,6 +33,13 @@ def calculate_all_metrics(
             "unit-of-measurement": "Pa",
             "description": ("The peak pressure amplitude within the brain."),
         },
+        "focal_position": {
+            "value": calculate_focal_position(result, layer="brain"),
+            "unit-of-measurement": "voxel-index",
+            "description": (
+                "The position of the peak pressure amplitude within the brain."
+            ),
+        },
         "focal_volume": {
             "value": calculate_focal_volume(result, layer="brain"),
             "unit-of-measurement": "voxels",

--- a/src/neurotechdevkit/results/_metrics.py
+++ b/src/neurotechdevkit/results/_metrics.py
@@ -11,7 +11,7 @@ from . import _results as results
 
 def calculate_all_metrics(
     result: results.SteadyStateResult,
-) -> dict[str, dict[str, float | int | str]]:
+) -> dict[str, dict[str, float | int | str | tuple]]:
     """Calculate all metrics for the steady-state result and return as a dictionary.
 
     The keys for the dictionary are the names of the metrics. The value for each metric

--- a/src/neurotechdevkit/results/_results.py
+++ b/src/neurotechdevkit/results/_results.py
@@ -183,7 +183,7 @@ class SteadyStateResult(Result):
         return self.steady_state
 
     @property
-    def metrics(self) -> dict[str, dict[str, str | float]]:
+    def metrics(self) -> dict[str, dict[str, str | float | int | tuple]]:
         """A dictionary containing metrics and their descriptions.
 
         The keys for the dictionary are the names of the metrics. The value for each

--- a/src/neurotechdevkit/scenarios/built_in/_scenario_1.py
+++ b/src/neurotechdevkit/scenarios/built_in/_scenario_1.py
@@ -167,7 +167,6 @@ class Scenario1_3D(Scenario1, Scenario3D):
 
 
 def _create_scenario_1_mask(material, grid):
-
     # layers are defined by X position
     dx = grid.space.spacing[0]
 

--- a/src/neurotechdevkit/sources.py
+++ b/src/neurotechdevkit/sources.py
@@ -1323,7 +1323,6 @@ class PhasedArraySource3D(PhasedArraySource):
         n_remaining = n_points - points.shape[0]
 
         if n_remaining > 0:
-
             # First compute the center
             x_width = x_max - x_min
             centre = np.array([(x_min + x_max) / 2, height / 2])

--- a/tests/neurotechdevkit/scenarios/test_metrics.py
+++ b/tests/neurotechdevkit/scenarios/test_metrics.py
@@ -12,7 +12,6 @@ from neurotechdevkit.results._metrics import (
     calculate_focal_fwhm,
     calculate_focal_gain,
     calculate_focal_pressure,
-    calculate_focal_position,
     calculate_focal_volume,
     calculate_i_pa_off_target,
     calculate_i_pa_target,


### PR DESCRIPTION
https://github.com/agencyenterprise/neurotechdevkit/issues/171

#### Introduction

Introduction from `plot_time_reverse.py`:

> The skull adds aberrations to the beam propagation; phased arrays can compensate for those by having different delays for each element, but estimating these delays can be challenging. One method to estimate the delays is a "time reverse" simulation as described in this [Article](https://koreascience.kr/article/JAKO200612242715181.pdf). This notebook demonstrates the "time reverse" method to estimate the delays. The notebook sets up a scenario with a phased array source and a target and then runs a simulation with the source and target reversed to calculate the delays. Finally, it uses the calculated delays to perform a forward-time simulation.

The time-reverse simulation was still using an old API `.add_source` so it had both the default source and the 

#### Changes

* Remove the default source from the time-reverse simulation

#### Behavior

* Tested locally that resulting delays are correct (on the order of 40microseconds)
* Docs generate properly and show the point-source simulation