### PR TITLE
Add interp dimension in nearest-neighbors interpolation to match linear interpolation

### DIFF
--- a/src/neurotechdevkit/imaging/beamform.py
+++ b/src/neurotechdevkit/imaging/beamform.py
@@ -477,7 +477,7 @@ def _interpolate_onto_pixel_grid(
             time_idx_float <= (max_time_samples - 1)
         )
         time_idx_round = time_idx_float.round()
-        # Add dimension to match other interpolation methdos
+        # Add dimension to match other interpolation methods
         time_idx_round = time_idx_round.expand_dims("interp")
     elif method == InterpolationMethod.LINEAR:
         # E.g., a time index of 2.3 gets 0.7*pixel_2 + 0.3*pixel_3

--- a/src/neurotechdevkit/imaging/beamform.py
+++ b/src/neurotechdevkit/imaging/beamform.py
@@ -477,6 +477,8 @@ def _interpolate_onto_pixel_grid(
             time_idx_float <= (max_time_samples - 1)
         )
         time_idx_round = time_idx_float.round()
+        # Add dimension to match other interpolation methdos
+        time_idx_round = time_idx_round.expand_dims("interp")
     elif method == InterpolationMethod.LINEAR:
         # E.g., a time index of 2.3 gets 0.7*pixel_2 + 0.3*pixel_3
         is_valid_time_idx = (time_idx_float >= 0) & (

--- a/tests/neurotechdevkit/imaging/test_beamform.py
+++ b/tests/neurotechdevkit/imaging/test_beamform.py
@@ -11,6 +11,7 @@ from neurotechdevkit.imaging.beamform import (
     _optimize_f_number,
     beamform_delay_and_sum,
     delay_and_sum_matrix,
+    InterpolationMethod,
 )
 
 
@@ -89,6 +90,22 @@ def test_delay_and_sum_matrix_outside_aperture(simple_inputs):
 
 
 def test_delay_and_sum(simple_inputs):
+    num_time_samples = simple_inputs["num_time_samples"]
+    num_channels = simple_inputs["num_channels"]
+
+    iq_signals = np.random.rand(num_time_samples, num_channels) + 1j * np.random.rand(
+        num_time_samples, num_channels
+    )
+    del simple_inputs["num_time_samples"]
+    del simple_inputs["num_channels"]
+
+    beamformed_iq_signals = beamform_delay_and_sum(iq_signals, **simple_inputs)
+    assert beamformed_iq_signals.shape == simple_inputs["x"].shape
+
+
+def test_delay_and_sum_nearest_neighbors_interpolation(simple_inputs):
+    simple_inputs["method"] = InterpolationMethod.NEAREST
+
     num_time_samples = simple_inputs["num_time_samples"]
     num_channels = simple_inputs["num_channels"]
 

--- a/tests/neurotechdevkit/imaging/test_beamform.py
+++ b/tests/neurotechdevkit/imaging/test_beamform.py
@@ -6,12 +6,12 @@ import xarray as xr
 from scipy.sparse import csr_array
 
 from neurotechdevkit.imaging.beamform import (
+    InterpolationMethod,
     _calculate_time_of_flight,
     _directivity,
     _optimize_f_number,
     beamform_delay_and_sum,
     delay_and_sum_matrix,
-    InterpolationMethod,
 )
 
 


### PR DESCRIPTION
#### Introduction

Bugfix: the `beamform.py` code expects an `interp` dimension, even though this is not added in the nearest-neighbors interpolation method 

#### Changes

* Add singleton `interp` dimension to the nearest-neighbors matrix construction
* Test nearest-neighbors interpolation code-path in unit tests

#### Behavior

* New unit test passes