### PR TITLE
Updagrading gh-pages package so it supports --no-history

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - run:
           name: Install and configure dependencies
           command: |
-            npm install -g --silent gh-pages@2.0.1
+            npm install -g --silent gh-pages@6.1.1
             git config user.email "bcibotae@ae.studio"
             git config user.name "bcibotae"
       - add_ssh_keys:


### PR DESCRIPTION
#### Introduction
CI failed on main because the flag added on [PR](https://github.com/agencyenterprise/neurotechdevkit/pull/183) is not supported on that package version
 
#### Changes
Updating gh-pages dependency version