### PR TITLE
Fix beamforming batching

### DIFF
--- a/src/neurotechdevkit/imaging/beamform.py
+++ b/src/neurotechdevkit/imaging/beamform.py
@@ -90,9 +90,15 @@ def beamform_delay_and_sum(
     )
 
     # Beamform
-    iq_signals_column_vec = iq_signals.reshape(-1, 1)
+    if iq_signals.ndim == 2:
+        iq_signals_column_vec = iq_signals.reshape(-1, 1)
+    else:
+        iq_signals_column_vec = iq_signals.reshape(-1, num_echoes)
     beamformed_iq_signals = das_matrix @ iq_signals_column_vec
-    beamformed_iq_signals = beamformed_iq_signals.reshape(x.shape)
+    if iq_signals.ndim == 2:
+        beamformed_iq_signals = beamformed_iq_signals.reshape(x.shape)
+    else:
+        beamformed_iq_signals = beamformed_iq_signals.reshape(x.shape + (-1,))
 
     return beamformed_iq_signals
 


### PR DESCRIPTION
Previously, the `beamform_delay_and_sum()` implementation did not properly handle the case where `iq_signals` has an extra batch dimension for echoes, so downstream computations did not work due to shape mismatch.

This PR modifies the implementation to properly handle the cases when `iq_signals` has an echoes dimensino and also when it doesn't.